### PR TITLE
[RI-11328] Fix crash when displaying action menu on iPad.

### DIFF
--- a/Aardvark.podspec
+++ b/Aardvark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Aardvark'
-  s.version  = '1.1.1'
+  s.version  = '1.1.2'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark is a library that makes it dead simple to create actionable bug reports.'
   s.homepage = 'https://github.com/square/Aardvark'

--- a/AardvarkTests/ARKDefaultLogFormatterTests.m
+++ b/AardvarkTests/ARKDefaultLogFormatterTests.m
@@ -59,13 +59,6 @@
     self.logStore = logStore;
 }
 
-- (void)tearDown;
-{
-    [ARKLogDistributor defaultDistributor].defaultLogStore = nil;
-    
-    [super tearDown];
-}
-
 #pragma mark - Behavior Tests
 
 - (void)test_formattedLogMessage_errorLogLineCount;

--- a/AardvarkTests/ARKEmailBugReporterTests.m
+++ b/AardvarkTests/ARKEmailBugReporterTests.m
@@ -61,13 +61,6 @@
     self.logStore = logStore;
 }
 
-- (void)tearDown;
-{
-    [ARKLogDistributor defaultDistributor].defaultLogStore = nil;
-    
-    [super tearDown];
-}
-
 #pragma mark - Behavior Tests
 
 - (void)test_recentErrorLogMessagesAsPlainText_countRespected;

--- a/AardvarkTests/ARKLogDistributorTests.m
+++ b/AardvarkTests/ARKLogDistributorTests.m
@@ -103,7 +103,6 @@ typedef void (^LogHandlingBlock)(ARKLogMessage *logMessage);
 {
     [self.logDistributor waitUntilAllPendingLogsHaveBeenDistributed];
     
-    self.logDistributor.defaultLogStore = nil;
     self.logDistributor.logMessageClass = [ARKLogMessage class];
     
     [super tearDown];
@@ -152,9 +151,6 @@ typedef void (^LogHandlingBlock)(ARKLogMessage *logMessage);
 
     // Should return the same instance on subsequent property accesses.
     XCTAssertEqual(logDistributor.defaultLogStore, defaultLogStore);
-    
-    logDistributor.defaultLogStore = nil;
-    XCTAssertNil(logDistributor.defaultLogStore, @"Default log store should not initialize itself lazily twice.");
 }
 
 - (void)test_addLogObserver_notifiesLogObserverOnLogWithFormat;

--- a/AardvarkTests/ARKLogTableViewControllerTests.m
+++ b/AardvarkTests/ARKLogTableViewControllerTests.m
@@ -120,13 +120,6 @@
     self.logStore = logStore;
 }
 
-- (void)tearDown;
-{
-    self.logDistributor.defaultLogStore = nil;
-    
-    [super tearDown];
-}
-
 #pragma mark - Behavior Tests
 
 - (void)test_logMessagesWithMinuteSeparators_insertsTimestampsBetweenLogs;

--- a/Log Viewing/ARKLogTableViewController.h
+++ b/Log Viewing/ARKLogTableViewController.h
@@ -31,7 +31,16 @@ NS_ASSUME_NONNULL_BEGIN
 /// Displays a list of ARKArdvarkLogs in a table.
 @interface ARKLogTableViewController : UITableViewController
 
-- (nullable instancetype)initWithLogStore:(ARKLogStore *)logStore logFormatter:(id <ARKLogFormatter>)logFormatter;
+/**
+ Creates a log table view controller displaying logs from the default `ARKLogDistributor`'s default log store, using a default log formatter.
+ */
+- (instancetype)init;
+
+/**
+ @param logStore The log store from which to display logs. Must not be nil.
+ @param logFormatter A log formatter used to format display of log messages. Must not be nil.
+ */
+- (nullable instancetype)initWithLogStore:(nonnull ARKLogStore *)logStore logFormatter:(nonnull id <ARKLogFormatter>)logFormatter NS_DESIGNATED_INITIALIZER;
 
 /// The log store that provides the data for the table.
 @property (nonatomic, readonly) ARKLogStore *logStore;

--- a/Log Viewing/ARKLogTableViewController.h
+++ b/Log Viewing/ARKLogTableViewController.h
@@ -31,16 +31,30 @@ NS_ASSUME_NONNULL_BEGIN
 /// Displays a list of ARKArdvarkLogs in a table.
 @interface ARKLogTableViewController : UITableViewController
 
+//
+// @name Init
+//
+
 /**
  Creates a log table view controller displaying logs from the default `ARKLogDistributor`'s default log store, using a default log formatter.
  */
-- (instancetype)init;
+- (nullable instancetype)init;
+
+/// @see `init`
+- (nullable instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil;
 
 /**
  @param logStore The log store from which to display logs. Must not be nil.
  @param logFormatter A log formatter used to format display of log messages. Must not be nil.
  */
 - (nullable instancetype)initWithLogStore:(nonnull ARKLogStore *)logStore logFormatter:(nonnull id <ARKLogFormatter>)logFormatter NS_DESIGNATED_INITIALIZER;
+
+- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
+- (nullable instancetype)initWithStyle:(UITableViewStyle)style NS_UNAVAILABLE;
+
+//
+// @name Properties
+//
 
 /// The log store that provides the data for the table.
 @property (nonatomic, readonly) ARKLogStore *logStore;

--- a/Log Viewing/ARKLogTableViewController.h
+++ b/Log Viewing/ARKLogTableViewController.h
@@ -41,16 +41,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)init;
 
 /// @see `init`
-- (nullable instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil;
+- (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil bundle:(nullable NSBundle *)nibBundleOrNil;
 
 /**
  @param logStore The log store from which to display logs. Must not be nil.
  @param logFormatter A log formatter used to format display of log messages. Must not be nil.
  */
-- (nullable instancetype)initWithLogStore:(nonnull ARKLogStore *)logStore logFormatter:(nonnull id <ARKLogFormatter>)logFormatter NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithLogStore:(ARKLogStore *)logStore logFormatter:(id <ARKLogFormatter>)logFormatter NS_DESIGNATED_INITIALIZER;
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
-- (nullable instancetype)initWithStyle:(UITableViewStyle)style NS_UNAVAILABLE;
+- (instancetype)initWithStyle:(UITableViewStyle)style NS_UNAVAILABLE;
 
 //
 // @name Properties

--- a/Log Viewing/ARKLogTableViewController.m
+++ b/Log Viewing/ARKLogTableViewController.m
@@ -38,7 +38,7 @@
 @property (nonatomic) BOOL hasScrolledToBottom;
 
 @property (nonatomic) UIActionSheet *clearLogsConfirmationActionSheet;
-@property (nonatomic, strong) UIBarButtonItem *shareBarButtonItem;
+@property (nonatomic, weak) UIBarButtonItem *shareBarButtonItem;
 
 #if TARGET_IPHONE_SIMULATOR
 @property (nonatomic) UIActionSheet *printLogsActionSheet;
@@ -53,10 +53,10 @@
 
 #pragma mark - Initialization
 
-- (instancetype)initWithLogStore:(ARKLogStore *)logStore logFormatter:(id <ARKLogFormatter>)logFormatter;
+- (nullable instancetype)initWithLogStore:(ARKLogStore *)logStore logFormatter:(id <ARKLogFormatter>)logFormatter;
 {
-    NSAssert(logStore, @"Must pass a log store.");
-    NSAssert(logFormatter, @"Must pass a logFormatter.");
+    ARKCheckCondition(logStore, nil, @"Must pass a log store.");
+    ARKCheckCondition(logFormatter, nil, @"Must pass a logFormatter.");
 
     self = [super initWithNibName:nil bundle:nil];
     if (!self) {
@@ -70,26 +70,24 @@
     return self;
 }
 
-- (instancetype)init;
+- (nullable instancetype)init;
 {
     return [self initWithLogStore:[ARKLogDistributor defaultDistributor].defaultLogStore logFormatter:[ARKDefaultLogFormatter new]];
 }
 
-- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil;
+- (nullable instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil;
 {
     return [self init];
 }
 
-- (instancetype)initWithCoder:(NSCoder *)aDecoder;
+- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder;
 {
-    NSAssert(NO, @"Please use a supported initializer.");
-    return [self init];
+    ARKCheckCondition(NO, nil, @"Please use a valid initializer.");
 }
 
-- (instancetype)initWithStyle:(UITableViewStyle)style;
+- (nullable instancetype)initWithStyle:(UITableViewStyle)style;
 {
-    NSAssert(NO, @"Please use a supported initializer.");
-    return [self init];
+    ARKCheckCondition(NO, nil, @"Please use a valid initializer.");
 }
 
 - (void)dealloc;
@@ -351,8 +349,10 @@
         [self presentViewController:activityViewController animated:YES completion:NULL];
     } else {
         // isPad
+        ARKCheckCondition(self.shareBarButtonItem, , @"Missing a share bar button item when that bar button item was clicked.");
+
         UIPopoverController *popoverController = [[UIPopoverController alloc] initWithContentViewController:activityViewController];
-        [popoverController presentPopoverFromBarButtonItem:self.shareBarButtonItem permittedArrowDirections:UIPopoverArrowDirectionAny  animated:YES];
+        [popoverController presentPopoverFromBarButtonItem:self.shareBarButtonItem permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
     }
 #endif
 }

--- a/Log Viewing/ARKLogTableViewController.m
+++ b/Log Viewing/ARKLogTableViewController.m
@@ -75,7 +75,7 @@
     return [self initWithLogStore:[ARKLogDistributor defaultDistributor].defaultLogStore logFormatter:[ARKDefaultLogFormatter new]];
 }
 
-- (nullable instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil;
+- (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil bundle:(nullable NSBundle *)nibBundleOrNil;
 {
     return [self init];
 }
@@ -85,9 +85,9 @@
     ARKCheckCondition(NO, nil, @"Please use a valid initializer.");
 }
 
-- (nullable instancetype)initWithStyle:(UITableViewStyle)style;
+- (instancetype)initWithStyle:(UITableViewStyle)style;
 {
-    ARKCheckCondition(NO, nil, @"Please use a valid initializer.");
+    ARKCheckCondition(NO, [self init], @"Please use a valid initializer.");
 }
 
 - (void)dealloc;

--- a/Logging/ARKLogDistributor.h
+++ b/Logging/ARKLogDistributor.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property Class logMessageClass;
 
 /// Convenience method to store a reference to the default log store. Lazily creates a log store when accessed for the first time if one is not already set.
-@property (nullable) ARKLogStore *defaultLogStore;
+@property ARKLogStore *defaultLogStore;
 
 /// Returns all instances of `ARKLogStore` that are currently registered as observers on this log distributor.
 @property (atomic, copy, readonly) NSSet *logStores;

--- a/Logging/ARKLogDistributor.m
+++ b/Logging/ARKLogDistributor.m
@@ -165,18 +165,6 @@
     return [logStores copy];
 }
 
-#pragma mark - Private Properties
-
-- (dispatch_once_t)defaultLogStoreAccessOnceToken;
-{
-    ARKCheckCondition(NO, 0, @"Should not attempt to access this token via a getter. This property must be used directly.");
-}
-
-- (void)setDefaultLogStoreAccessOnceToken:(dispatch_once_t)defaultLogStoreAccessOnceToken;
-{
-    ARKCheckCondition(NO, , @"Should not attempt to set this token via the setter. This property must be used directly.");
-}
-
 #pragma mark - Public Methods - Log Observers
 
 - (void)addLogObserver:(id <ARKLogObserver>)logObserver;

--- a/Logging/ARKLogStore.h
+++ b/Logging/ARKLogStore.h
@@ -28,10 +28,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ARKLogStore : NSObject <ARKLogObserver>
 
 /// Creates an ARKLogStore with persistedLogFileURL set to the supplied fileName within the application support directory and a maximumLogMessageCount of logs to persist.
-- (nullable instancetype)initWithPersistedLogFileName:(NSString *)fileName maximumLogMessageCount:(NSUInteger)maximumLogMessageCount;
+- (nullable instancetype)initWithPersistedLogFileName:(NSString *)fileName maximumLogMessageCount:(NSUInteger)maximumLogMessageCount NS_DESIGNATED_INITIALIZER;
 
 /// Creates an ARKLogStore with persistedLogsFileURL set to the supplied fileName within the application support directory that keeps a maximum of 2000 logs persisted.
 - (nullable instancetype)initWithPersistedLogFileName:(NSString *)fileName;
+
+- (nullable instancetype)init NS_UNAVAILABLE;
++ (nullable instancetype)new NS_UNAVAILABLE;
 
 /// Path to the file on disk that contains peristed logs.
 @property (nonatomic, copy, readonly) NSURL *persistedLogFileURL;

--- a/Logging/ARKLogStore.m
+++ b/Logging/ARKLogStore.m
@@ -32,7 +32,7 @@
 @interface ARKLogStore ()
 
 /// Stores all log messages.
-@property ARKDataArchive *dataArchive;
+@property (nonnull) ARKDataArchive *dataArchive;
 
 @end
 
@@ -43,12 +43,7 @@
 
 #pragma mark - Initialization
 
-- (instancetype)init;
-{
-    ARKCheckCondition(NO, nil, @"Must use -initWithPersistedLogFileName: to initialize a ARKLogStore");
-}
-
-- (instancetype)initWithPersistedLogFileName:(NSString *)fileName maximumLogMessageCount:(NSUInteger)maximumLogMessageCount;
+- (nullable instancetype)initWithPersistedLogFileName:(nonnull NSString *)fileName maximumLogMessageCount:(NSUInteger)maximumLogMessageCount;
 {
     ARKCheckCondition(fileName.length > 0, nil, @"Must specify a file name");
     ARKCheckCondition(maximumLogMessageCount > 0, nil, @"maximumLogMessageCount must be greater than zero");
@@ -68,9 +63,14 @@
     return self;
 }
 
-- (instancetype)initWithPersistedLogFileName:(NSString *)fileName;
+- (nullable instancetype)initWithPersistedLogFileName:(NSString *)fileName;
 {
     return [self initWithPersistedLogFileName:fileName maximumLogMessageCount:2000];
+}
+
+- (nullable instancetype)init;
+{
+    ARKCheckCondition(NO, nil, @"Must use -initWithPersistedLogFileName: to initialize an ARKLogStore");
 }
 
 - (void)dealloc;
@@ -80,7 +80,7 @@
 
 #pragma mark - ARKLogDistributor
 
-- (void)observeLogMessage:(ARKLogMessage *)logMessage;
+- (void)observeLogMessage:(nonnull ARKLogMessage *)logMessage;
 {
     if (self.logFilterBlock && !self.logFilterBlock(logMessage)) {
         // Predicate told us we should not observe this log. Bail out.
@@ -100,7 +100,7 @@
 
 #pragma mark - Public Methods
 
-- (void)retrieveAllLogMessagesWithCompletionHandler:(void (^)(NSArray *logMessages))completionHandler;
+- (void)retrieveAllLogMessagesWithCompletionHandler:(nonnull void (^)(NSArray *logMessages))completionHandler;
 {
     ARKCheckCondition(completionHandler != NULL, , @"Can not retrieve log messages without a completion handler");
     if (self.logDistributor == nil) {
@@ -116,7 +116,7 @@
     }];
 }
 
-- (void)clearLogsWithCompletionHandler:(dispatch_block_t)completionHandler;
+- (void)clearLogsWithCompletionHandler:(nullable dispatch_block_t)completionHandler;
 {
     if (self.logDistributor == nil) {
         [self.dataArchive clearArchiveWithCompletionHandler:completionHandler];
@@ -129,7 +129,7 @@
 
 #pragma mark - Private Methods
 
-- (void)_applicationWillTerminate:(NSNotification *)notification;
+- (void)_applicationWillTerminate:(nullable NSNotification *)notification;
 {
     [self.logDistributor waitUntilAllPendingLogsHaveBeenDistributed];
     [self.dataArchive saveArchiveAndWait:YES];


### PR DESCRIPTION
[RI-11328] Fixes crash when displaying action menu on iPad. Improves initializer correctness.

Changes:
- Obey Apple's guidelines for displaying UIActivityViewController - was causing crashes on iPad when trying to display.
- Enforce passing a non-nil logStore and formatter to the ARKLogTableViewController. Deeper down the stack, the logFormatter is used to add formatted log messages to an array. This fails when one is missing. 
- Ensure that we override our superclasses designated initializers. Mark one of our initializers as designated. Ensure our designated initializer calls through to (one of) our superclasses designated initializers.