### PR TITLE
Add a mechanism to specify dynamic key-value pairs in the prefill email body of a bug report

### DIFF
--- a/Aardvark.podspec
+++ b/Aardvark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Aardvark'
-  s.version  = '1.1.3'
+  s.version  = '1.2.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark is a library that makes it dead simple to create actionable bug reports.'
   s.homepage = 'https://github.com/square/Aardvark'

--- a/Bug Reporting/ARKEmailBugReporter.h
+++ b/Bug Reporting/ARKEmailBugReporter.h
@@ -22,11 +22,22 @@
 #import <MessageUI/MessageUI.h>
 
 
+@class ARKEmailBugReporter;
 @class ARKLogStore;
 @protocol ARKLogFormatter;
 
 
 NS_ASSUME_NONNULL_BEGIN
+
+
+@protocol ARKEmailBugReporterEmailBodyAdditionsDelegate <NSObject>
+
+@required
+
+/// Called on the main thread when a bug is filed. The key/value pairs in the returned dictionary will be appended to the bug report below the prefilledEmailBody.
+- (nullable NSDictionary *)emailBodyAdditionsForEmailBugReporter:(ARKEmailBugReporter *)emailBugReporter;
+
+@end
 
 
 /// Composes a bug report that is sent via email.
@@ -39,6 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// The email body that will be presented to the user when they compose a report.
 @property (nonatomic, copy) NSString *prefilledEmailBody;
+
+/// The email body delegate, responsible for providing key/value pairs to include in the bug report at the time the bug is filed.
+@property (nullable, nonatomic, weak) id <ARKEmailBugReporterEmailBodyAdditionsDelegate> emailBodyAdditionsDelegate;
 
 /// The formatter used to prepare the log for entry into an email. Defaults to a vanilla instance of ARKDefaultLogFormatter.
 @property (nonatomic) id <ARKLogFormatter> logFormatter;

--- a/Bug Reporting/ARKEmailBugReporter.m
+++ b/Bug Reporting/ARKEmailBugReporter.m
@@ -196,6 +196,15 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
                     // Only attach data once all log messages have been retrieved.
                     if (logStoresToLogMessagesMap.count == logStores.count) {
                         NSMutableString *emailBody = [NSMutableString stringWithFormat:@"%@\n", self.prefilledEmailBody];
+                        
+                        NSDictionary *emailBodyAdditions = [self.emailBodyAdditionsDelegate emailBodyAdditionsForEmailBugReporter:self];
+                        if (emailBodyAdditions.count > 0) {
+                            [emailBody appendString:@"\n"];
+                            for (NSString *emailBodyAdditionKey in emailBodyAdditions.allKeys) {
+                                [emailBody appendFormat:@"%@: %@\n", emailBodyAdditionKey, emailBodyAdditions[emailBodyAdditionKey]];
+                            }
+                        }
+                        
                         for (ARKLogStore *logStore in logStores) {
                             NSArray *logMessages = [logStoresToLogMessagesMap objectForKey:logStore];
                             

--- a/Bug Reporting/ARKEmailBugReporter.m
+++ b/Bug Reporting/ARKEmailBugReporter.m
@@ -63,7 +63,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
                            @"2. \n"
                            @"3. \n"
                            @"\n"
-                           @"System version: %@\n", [[UIDevice currentDevice] systemVersion]];
+                           @"System version: %@", [[UIDevice currentDevice] systemVersion]];
     
     _logFormatter = [ARKDefaultLogFormatter new];
     _numberOfRecentErrorLogsToIncludeInEmailBodyWhenAttachmentsAreAvailable = 3;
@@ -199,11 +199,13 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
                         
                         NSDictionary *emailBodyAdditions = [self.emailBodyAdditionsDelegate emailBodyAdditionsForEmailBugReporter:self];
                         if (emailBodyAdditions.count > 0) {
-                            [emailBody appendString:@"\n"];
                             for (NSString *emailBodyAdditionKey in emailBodyAdditions.allKeys) {
                                 [emailBody appendFormat:@"%@: %@\n", emailBodyAdditionKey, emailBodyAdditions[emailBodyAdditionKey]];
                             }
                         }
+                        
+                        // Add a newline to separate prefill email body from what comes below.
+                        [emailBody appendString:@"\n"];
                         
                         for (ARKLogStore *logStore in logStores) {
                             NSArray *logMessages = [logStoresToLogMessagesMap objectForKey:logStore];

--- a/Logging/ARKLogDistributor.m
+++ b/Logging/ARKLogDistributor.m
@@ -75,11 +75,7 @@
     _logDistributingQueue.name = [NSString stringWithFormat:@"%@ Log Distributing Queue", self];
     _logDistributingQueue.maxConcurrentOperationCount = 1;
 
-#ifdef __IPHONE_8_0
-    if ([_logDistributingQueue respondsToSelector:@selector(setQualityOfService:)] /* iOS 8 or later */) {
-        _logDistributingQueue.qualityOfService = NSQualityOfServiceBackground;
-    }
-#endif
+    [self _setDistributionQualityOfServiceBackground];
     
     _logObservers = [NSMutableArray new];
 
@@ -191,8 +187,10 @@
 {
     ARKCheckCondition(completionHandler != NULL, , @"Must provide a completion handler!");
     
+    [self _setDistributionQualityOfServiceUserInitiated];
     [self.logDistributingQueue addOperationWithBlock:^{
         [[NSOperationQueue mainQueue] addOperationWithBlock:completionHandler];
+        [self _setDistributionQualityOfServiceBackground];
     }];
 }
 
@@ -283,5 +281,30 @@
         [logObserver observeLogMessage:logMessage];
     }
 }
+
+- (void)_setDistributionQualityOfServiceUserInitiated;
+{
+#ifdef __IPHONE_8_0
+    [self _setDistributionQualityOfService:NSQualityOfServiceUserInitiated];
+#endif
+}
+
+- (void)_setDistributionQualityOfServiceBackground;
+{
+#ifdef __IPHONE_8_0
+    [self _setDistributionQualityOfService:NSQualityOfServiceBackground];
+#endif
+}
+
+#ifdef __IPHONE_8_0
+
+- (void)_setDistributionQualityOfService:(NSQualityOfService)qualityOfService;
+{
+    if ([self.logDistributingQueue respondsToSelector:@selector(setQualityOfService:)] /* iOS 8 or later */) {
+        self.logDistributingQueue.qualityOfService = qualityOfService;
+    }
+}
+
+#endif
 
 @end


### PR DESCRIPTION
cc @shawnwelch @rhgills @mthole 

This should allow us to stop setting the `prefilledEmailBody` at setup time, and start providing key/value pairs on-demand. This will allow us to easily provide the correct user token or wifi network (among other dynamic content) at bug file time.