### PR TITLE
[RI-11337] Add singleton ARKEmailBugReporter.

### DIFF
--- a/Aardvark/Aardvark.h
+++ b/Aardvark/Aardvark.h
@@ -52,6 +52,9 @@ OBJC_EXTERN void ARKLogScreenshot();
 /// Sets up a two finger press-and-hold gesture recognizer to trigger email bug reports that will be sent to emailAddress. Returns the created bug reporter for convenience.
 + (nullable ARKEmailBugReporter *)addDefaultBugReportingGestureWithEmailBugReporterWithRecipient:(NSString *)emailAddress;
 
+/// Sets up a two finger press-and-hold gesture recognizer to trigger the passed in email bug reporter.
++ (void)addDefaultBugReportingGestureWithEmailBugReporter:(ARKEmailBugReporter *)bugReporter;
+
 /// Creates and returns a gesture recognizer that when triggered will call [bugReporter composeBugReport].
 + (nullable id)addBugReporter:(id <ARKBugReporter>)bugReporter triggeringGestureRecognizerClass:(Class)gestureRecognizerClass;
 

--- a/Aardvark/Aardvark.m
+++ b/Aardvark/Aardvark.m
@@ -57,13 +57,19 @@ void ARKLogScreenshot()
 + (ARKEmailBugReporter *)addDefaultBugReportingGestureWithEmailBugReporterWithRecipient:(NSString *)emailAddress;
 {
     ARKCheckCondition([[UIApplication sharedApplication] respondsToSelector:@selector(ARK_addTwoFingerPressAndHoldGestureRecognizerTriggerWithBugReporter:)], nil, @"Add -ObjC to your project's Other Linker Flags to use %s", __PRETTY_FUNCTION__);
-    
+
     ARKLogStore *logStore = [ARKLogDistributor defaultDistributor].defaultLogStore;
     ARKEmailBugReporter *bugReporter = [[ARKEmailBugReporter alloc] initWithEmailAddress:emailAddress logStore:logStore];
-    
-    [[UIApplication sharedApplication] ARK_addTwoFingerPressAndHoldGestureRecognizerTriggerWithBugReporter:bugReporter];
-    
+    [self addDefaultBugReportingGestureWithEmailBugReporter:bugReporter];
+
     return bugReporter;
+}
+
++ (void)addDefaultBugReportingGestureWithEmailBugReporter:(ARKEmailBugReporter *)bugReporter;
+{
+    ARKCheckCondition([[UIApplication sharedApplication] respondsToSelector:@selector(ARK_addTwoFingerPressAndHoldGestureRecognizerTriggerWithBugReporter:)],, @"Add -ObjC to your project's Other Linker Flags to use %s", __PRETTY_FUNCTION__);
+
+    [[UIApplication sharedApplication] ARK_addTwoFingerPressAndHoldGestureRecognizerTriggerWithBugReporter:bugReporter];
 }
 
 + (id)addBugReporter:(id <ARKBugReporter>)bugReporter triggeringGestureRecognizerClass:(Class)gestureRecognizerClass;

--- a/Bug Reporting/ARKEmailBugReporter.h
+++ b/Bug Reporting/ARKEmailBugReporter.h
@@ -32,6 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Composes a bug report that is sent via email.
 @interface ARKEmailBugReporter : NSObject <ARKBugReporter>
 
+/// Returns an instance of a default email bug reporter.
++ (instancetype)defaultReporter;
+
 - (instancetype)initWithEmailAddress:(NSString *)emailAddress logStore:(ARKLogStore *)logStore;
 
 /// The email address to which bug reports will be sent. Must be set before composeBugReport is called.

--- a/Bug Reporting/ARKEmailBugReporter.m
+++ b/Bug Reporting/ARKEmailBugReporter.m
@@ -51,6 +51,17 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 
 #pragma mark - Initialization
 
++ (instancetype)defaultReporter;
+{
+    static dispatch_once_t onceToken;
+    static ARKEmailBugReporter *bugReporter;
+    dispatch_once(&onceToken, ^{
+        bugReporter = [ARKEmailBugReporter new];
+    });
+
+    return bugReporter;
+}
+
 - (instancetype)init;
 {
     self = [super init];


### PR DESCRIPTION
This is needed for Register to easily add the Hardware Service log modules to the bug reporter.