### PR TITLE
[RI-11529] Fix iPad activity sheet crash on iOS 7.

### DIFF
--- a/Aardvark.podspec
+++ b/Aardvark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Aardvark'
-  s.version  = '1.1.2'
+  s.version  = '1.1.3'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark is a library that makes it dead simple to create actionable bug reports.'
   s.homepage = 'https://github.com/square/Aardvark'

--- a/Log Viewing/ARKLogTableViewController.m
+++ b/Log Viewing/ARKLogTableViewController.m
@@ -31,7 +31,7 @@
 #import "UIActivityViewController+ARKAdditions.h"
 
 
-@interface ARKLogTableViewController () <UIActionSheetDelegate>
+@interface ARKLogTableViewController () <UIActionSheetDelegate, UIPopoverControllerDelegate>
 
 @property (nonatomic, copy) NSArray *logMessages;
 @property (nonatomic) BOOL viewWillAppearForFirstTimeCalled;
@@ -39,6 +39,8 @@
 
 @property (nonatomic) UIActionSheet *clearLogsConfirmationActionSheet;
 @property (nonatomic, weak) UIBarButtonItem *shareBarButtonItem;
+
+@property (nonatomic, strong) UIPopoverController *activitySheetPopoverController;
 
 #if TARGET_IPHONE_SIMULATOR
 @property (nonatomic) UIActionSheet *printLogsActionSheet;
@@ -174,6 +176,13 @@
             [self _reloadLogs];
         }
     }
+}
+
+#pragma mark - UIPopoverControllerDelegate
+
+- (void)popoverControllerDidDismissPopover:(UIPopoverController *)popoverController;
+{
+    self.activitySheetPopoverController = nil;
 }
 
 #pragma mark - UITableViewDataSource
@@ -351,8 +360,9 @@
         // isPad
         ARKCheckCondition(self.shareBarButtonItem, , @"Missing a share bar button item when that bar button item was clicked.");
 
-        UIPopoverController *popoverController = [[UIPopoverController alloc] initWithContentViewController:activityViewController];
-        [popoverController presentPopoverFromBarButtonItem:self.shareBarButtonItem permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+        self.activitySheetPopoverController = [[UIPopoverController alloc] initWithContentViewController:activityViewController];
+        self.activitySheetPopoverController.delegate = self;
+        [self.activitySheetPopoverController presentPopoverFromBarButtonItem:self.shareBarButtonItem permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
     }
 #endif
 }


### PR DESCRIPTION
On iOS 7, the UIPopoverController is not retained as part of it being presented. Aardvark causes a crash as the the popover controller is deallocated while trying to present. To fix, we'll retain the popover controller after presenting until it is dismissed.