### PR TITLE
Allows skipping screenshot capture when triggering the creation

### DIFF
--- a/Bug Reporting/ARKBugReporter.h
+++ b/Bug Reporting/ARKBugReporter.h
@@ -26,8 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ARKBugReporter <NSObject>
 
-/// Called when the user has triggered the creation of a bug report.
+/// Called when the user has triggered the creation of a bug report. Logs a screenshot by default.
 - (void)composeBugReport;
+
+/// Called when the user has triggered the creation of a bug report, optionally, logs a screenshot.
+- (void)composeBugReportWithSreenshotLog:(BOOL)logScreenshot;
 
 /// Add logs from logStores to future bug reports.
 - (void)addLogStores:(NSArray *)logStores;

--- a/Bug Reporting/ARKBugReporter.h
+++ b/Bug Reporting/ARKBugReporter.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)composeBugReport;
 
 /// Called when the user has triggered the creation of a bug report, optionally, logs a screenshot.
-- (void)composeBugReportWithSreenshotLog:(BOOL)logScreenshot;
+- (void)composeBugReportWithScreenshotLog:(BOOL)logScreenshot;
 
 /// Add logs from logStores to future bug reports.
 - (void)addLogStores:(NSArray *)logStores;

--- a/Bug Reporting/ARKBugReporter.h
+++ b/Bug Reporting/ARKBugReporter.h
@@ -26,11 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ARKBugReporter <NSObject>
 
-/// Called when the user has triggered the creation of a bug report. Logs a screenshot by default.
+/// Called when the user has triggered the creation of a bug report, including a screenshot to the report.
 - (void)composeBugReport;
 
-/// Called when the user has triggered the creation of a bug report, optionally, logs a screenshot.
-- (void)composeBugReportWithScreenshotLog:(BOOL)logScreenshot;
+/// Called when the user has triggered the creation of a bug report, without the screenshot.
+- (void)composeBugReportWithoutScreenshot;
 
 /// Add logs from logStores to future bug reports.
 - (void)addLogStores:(NSArray *)logStores;

--- a/Bug Reporting/ARKEmailBugReporter.m
+++ b/Bug Reporting/ARKEmailBugReporter.m
@@ -253,10 +253,10 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
      */
     [self _stealFirstResponder];
     
-    NSString *title = @"What Went Wrong?";
-    NSString *message = @"Please briefly summarize the issue you just encountered. You’ll be asked for more details later.";
-    NSString *okTitle = @"Compose Report";
-    NSString *cancelTitle = @"Cancel";
+    NSString * const title = @"What Went Wrong?";
+    NSString * const message = @"Please briefly summarize the issue you just encountered. You’ll be asked for more details later.";
+    NSString * const okTitle = @"Compose Report";
+    NSString * const cancelTitle = @"Cancel";
     
     if ([UIAlertController class]) {
         UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];

--- a/Bug Reporting/ARKEmailBugReporter.m
+++ b/Bug Reporting/ARKEmailBugReporter.m
@@ -258,31 +258,32 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
     NSString * const composeReportButtonTitle = NSLocalizedString(@"Compose Report", nil);
     NSString * const cancelButtonTitle = NSLocalizedString(@"Cancel", nil);
     
-#ifdef __IPHONE_8_0
     // iOS 8 and later
-    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
-    
-    [alertController addAction:[UIAlertAction actionWithTitle:composeReportButtonTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-        UITextField *textfield = [alertController.textFields firstObject];
-        [self _createBugReportWithTitle:textfield.text];
-    }]];
-    
-    [alertController addAction:[UIAlertAction actionWithTitle:cancelButtonTitle style:UIAlertActionStyleDefault handler:NULL]];
-    
-    [alertController addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
+    if ([UIAlertController class]) {
+        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+        
+        [alertController addAction:[UIAlertAction actionWithTitle:composeReportButtonTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+            UITextField *textfield = [alertController.textFields firstObject];
+            [self _createBugReportWithTitle:textfield.text];
+        }]];
+        
+        [alertController addAction:[UIAlertAction actionWithTitle:cancelButtonTitle style:UIAlertActionStyleDefault handler:NULL]];
+        
+        [alertController addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
+            [self _configureAlertTextfield:textField];
+        }];
+        
+        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alertController animated:YES completion:NULL];
+    }
+    else {
+        UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title message:message delegate:self cancelButtonTitle:cancelButtonTitle otherButtonTitles:composeReportButtonTitle, nil];
+        alertView.alertViewStyle = UIAlertViewStylePlainTextInput;
+        
+        UITextField *textField = [alertView textFieldAtIndex:0];
         [self _configureAlertTextfield:textField];
-    }];
-    
-    [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alertController animated:YES completion:NULL];
-#else
-    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title message:message delegate:self cancelButtonTitle:cancelButtonTitle otherButtonTitles:composeReportButtonTitle, nil];
-    alertView.alertViewStyle = UIAlertViewStylePlainTextInput;
-    
-    UITextField *textField = [alertView textFieldAtIndex:0];
-    [self _configureAlertTextfield:textField];
-    
-    [alertView show];
-#endif
+        
+        [alertView show];
+    }
 }
 
 - (void)_configureAlertTextfield:(UITextField *)textField

--- a/Bug Reporting/ARKEmailBugReporter.m
+++ b/Bug Reporting/ARKEmailBugReporter.m
@@ -258,10 +258,10 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
      */
     [self _stealFirstResponder];
     
-    NSString * const title = NSLocalizedString(@"What Went Wrong?", nil);
-    NSString * const message = NSLocalizedString(@"Please briefly summarize the issue you just encountered. You’ll be asked for more details later.", nil);
-    NSString * const composeReportButtonTitle = NSLocalizedString(@"Compose Report", nil);
-    NSString * const cancelButtonTitle = NSLocalizedString(@"Cancel", nil);
+    NSString * const title = NSLocalizedString(@"What Went Wrong?", @"Title text for alert asking user to describe a bug they just encountered");
+    NSString * const message = NSLocalizedString(@"Please briefly summarize the issue you just encountered. You’ll be asked for more details later.", @"Subtitle text for alert asking user to describe a bug they just encountered");
+    NSString * const composeReportButtonTitle = NSLocalizedString(@"Compose Report", @"Button title to compose bug report");
+    NSString * const cancelButtonTitle = NSLocalizedString(@"Cancel", @"Button title to not compose a bug report");
     
     // iOS 8 and later
     if ([UIAlertController class]) {

--- a/Bug Reporting/ARKEmailBugReporter.m
+++ b/Bug Reporting/ARKEmailBugReporter.m
@@ -44,7 +44,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 
 @property (nonatomic, copy) NSMutableArray *mutableLogStores;
 
-@property (nonatomic) BOOL skipScreenshot;
+@property (nonatomic) BOOL logScreenshot;
 
 @end
 
@@ -102,9 +102,9 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
     ARKCheckCondition(self.bugReportRecipientEmailAddress.length, , @"Attempting to compose a bug report without a recipient email address.");
     ARKCheckCondition(self.mutableLogStores.count > 0, , @"Attempting to compose a bug report without logs.");
     
-    self.skipScreenshot = !logScreenshot;
+    self.logScreenshot = logScreenshot;
     
-    if (!self.screenFlashView && logScreenshot) {
+    if (self.logScreenshot && !self.screenFlashView) {
         // Take a screenshot.
         ARKLogScreenshot();
         
@@ -228,9 +228,12 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
                                 [emailBody appendString:emailBodyForLogStore];
                             }
                             
-                            NSData *mostRecentImage = [self _mostRecentImageAsPNG:logMessages];
-                            if (mostRecentImage.length && !self.skipScreenshot) {
-                                [self.mailComposeViewController addAttachmentData:mostRecentImage mimeType:@"image/png" fileName:screenshotFileName];
+                            
+                            if (self.logScreenshot) {
+                                NSData *mostRecentImage = [self _mostRecentImageAsPNG:logMessages];
+                                if (mostRecentImage.length) {
+                                    [self.mailComposeViewController addAttachmentData:mostRecentImage mimeType:@"image/png" fileName:screenshotFileName];
+                                }
                             }
                             
                             NSData *formattedLogs = [self formattedLogMessagesAsData:logMessages];

--- a/Bug Reporting/ARKEmailBugReporter.m
+++ b/Bug Reporting/ARKEmailBugReporter.m
@@ -262,14 +262,14 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
     if ([UIAlertController class]) {
         UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
         
-        [alertController addAction:[UIAlertAction actionWithTitle:composeReportButtonTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        [alertController addAction:[UIAlertAction actionWithTitle:composeReportButtonTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
             UITextField *textfield = [alertController.textFields firstObject];
             [self _createBugReportWithTitle:textfield.text];
         }]];
         
         [alertController addAction:[UIAlertAction actionWithTitle:cancelButtonTitle style:UIAlertActionStyleDefault handler:NULL]];
         
-        [alertController addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
+        [alertController addTextFieldWithConfigurationHandler:^(UITextField *textField) {
             [self _configureAlertTextfield:textField];
         }];
         

--- a/Bug Reporting/ARKEmailBugReporter.m
+++ b/Bug Reporting/ARKEmailBugReporter.m
@@ -187,7 +187,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
     if (alertView.firstOtherButtonIndex == buttonIndex) {
         NSString *bugTitle = [alertView textFieldAtIndex:0].text;
         
-        [self _shouldCreateReportWithTitle:bugTitle];
+        [self _createBugReportWithTitle:bugTitle];
     }
 }
 
@@ -253,20 +253,21 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
      */
     [self _stealFirstResponder];
     
-    NSString * const title = @"What Went Wrong?";
-    NSString * const message = @"Please briefly summarize the issue you just encountered. You’ll be asked for more details later.";
-    NSString * const okTitle = @"Compose Report";
-    NSString * const cancelTitle = @"Cancel";
+    NSString * const title = NSLocalizedString(@"What Went Wrong?", nil);
+    NSString * const message = NSLocalizedString(@"Please briefly summarize the issue you just encountered. You’ll be asked for more details later.", nil);
+    NSString * const composeReportButtonTitle = NSLocalizedString(@"Compose Report", nil);
+    NSString * const cancelButtonTitle = NSLocalizedString(@"Cancel", nil);
     
 #ifdef __IPHONE_8_0
+    // iOS 8 and later
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
     
-    [alertController addAction:[UIAlertAction actionWithTitle:okTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+    [alertController addAction:[UIAlertAction actionWithTitle:composeReportButtonTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
         UITextField *textfield = [alertController.textFields firstObject];
         [self _createBugReportWithTitle:textfield.text];
     }]];
     
-    [alertController addAction:[UIAlertAction actionWithTitle:cancelTitle style:UIAlertActionStyleDefault handler:NULL]];
+    [alertController addAction:[UIAlertAction actionWithTitle:cancelButtonTitle style:UIAlertActionStyleDefault handler:NULL]];
     
     [alertController addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
         [self _configureAlertTextfield:textField];
@@ -274,7 +275,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
     
     [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alertController animated:YES completion:NULL];
 #else
-    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title message:message delegate:self cancelButtonTitle:cancelTitle otherButtonTitles:okTitle, nil];
+    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title message:message delegate:self cancelButtonTitle:cancelButtonTitle otherButtonTitles:composeReportButtonTitle, nil];
     alertView.alertViewStyle = UIAlertViewStylePlainTextInput;
     
     UITextField *textField = [alertView textFieldAtIndex:0];
@@ -292,7 +293,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
     textField.returnKeyType = UIReturnKeyDone;
 }
 
-- (void)_shouldCreateReportWithTitle:(NSString *)title
+- (void)_createBugReportWithTitle:(NSString *)title
 {
     NSArray *logStores = [self.logStores copy];
     NSMapTable *logStoresToLogMessagesMap = [NSMapTable new];

--- a/Bug Reporting/ARKEmailBugReporter.m
+++ b/Bug Reporting/ARKEmailBugReporter.m
@@ -258,31 +258,30 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
     NSString * const okTitle = @"Compose Report";
     NSString * const cancelTitle = @"Cancel";
     
-    if ([UIAlertController class]) {
-        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
-        
-        [alertController addAction:[UIAlertAction actionWithTitle:okTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-            UITextField *textfield = [alertController.textFields firstObject];
-            [self _shouldCreateReportWithTitle:textfield.text];
-        }]];
-        
-        [alertController addAction:[UIAlertAction actionWithTitle:cancelTitle style:UIAlertActionStyleDefault handler:NULL]];
-        
-        [alertController addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
-            [self _configureAlertTextfield:textField];
-        }];
-        
-        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alertController animated:YES completion:NULL];
-    }
-    else {
-        UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title message:message delegate:self cancelButtonTitle:cancelTitle otherButtonTitles:okTitle, nil];
-        alertView.alertViewStyle = UIAlertViewStylePlainTextInput;
-        
-        UITextField *textField = [alertView textFieldAtIndex:0];
+#ifdef __IPHONE_8_0
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+    
+    [alertController addAction:[UIAlertAction actionWithTitle:okTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        UITextField *textfield = [alertController.textFields firstObject];
+        [self _createBugReportWithTitle:textfield.text];
+    }]];
+    
+    [alertController addAction:[UIAlertAction actionWithTitle:cancelTitle style:UIAlertActionStyleDefault handler:NULL]];
+    
+    [alertController addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
         [self _configureAlertTextfield:textField];
-        
-        [alertView show];
-    }
+    }];
+    
+    [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alertController animated:YES completion:NULL];
+#else
+    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title message:message delegate:self cancelButtonTitle:cancelTitle otherButtonTitles:okTitle, nil];
+    alertView.alertViewStyle = UIAlertViewStylePlainTextInput;
+    
+    UITextField *textField = [alertView textFieldAtIndex:0];
+    [self _configureAlertTextfield:textField];
+    
+    [alertView show];
+#endif
 }
 
 - (void)_configureAlertTextfield:(UITextField *)textField

--- a/Bug Reporting/ARKEmailBugReporter.m
+++ b/Bug Reporting/ARKEmailBugReporter.m
@@ -94,10 +94,10 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 
 - (void)composeBugReport;
 {
-    [self composeBugReportWithSreenshotLog:YES];
+    [self composeBugReportWithScreenshotLog:YES];
 }
 
-- (void)composeBugReportWithSreenshotLog:(BOOL)logScreenshot;
+- (void)composeBugReportWithScreenshotLog:(BOOL)logScreenshot;
 {
     ARKCheckCondition(self.bugReportRecipientEmailAddress.length, , @"Attempting to compose a bug report without a recipient email address.");
     ARKCheckCondition(self.mutableLogStores.count > 0, , @"Attempting to compose a bug report without logs.");

--- a/Bug Reporting/ARKEmailBugReporter.m
+++ b/Bug Reporting/ARKEmailBugReporter.m
@@ -44,7 +44,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 
 @property (nonatomic, copy) NSMutableArray *mutableLogStores;
 
-@property (nonatomic) BOOL logScreenshot;
+@property (nonatomic) BOOL attachScreenshotToNextBugReport;
 
 @end
 
@@ -94,17 +94,22 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 
 - (void)composeBugReport;
 {
-    [self composeBugReportWithScreenshotLog:YES];
+    [self composeBugReportWithScreenshot:YES];
 }
 
-- (void)composeBugReportWithScreenshotLog:(BOOL)logScreenshot;
+- (void)composeBugReportWithoutScreenshot;
+{
+    [self composeBugReportWithScreenshot:NO];
+}
+
+- (void)composeBugReportWithScreenshot:(BOOL)attachScreenshot;
 {
     ARKCheckCondition(self.bugReportRecipientEmailAddress.length, , @"Attempting to compose a bug report without a recipient email address.");
     ARKCheckCondition(self.mutableLogStores.count > 0, , @"Attempting to compose a bug report without logs.");
     
-    self.logScreenshot = logScreenshot;
+    self.attachScreenshotToNextBugReport = attachScreenshot;
     
-    if (self.logScreenshot && !self.screenFlashView) {
+    if (attachScreenshot && !self.screenFlashView) {
         // Take a screenshot.
         ARKLogScreenshot();
         
@@ -339,7 +344,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
                         }
                         
                         
-                        if (self.logScreenshot) {
+                        if (self.attachScreenshotToNextBugReport) {
                             NSData *mostRecentImage = [self _mostRecentImageAsPNG:logMessages];
                             if (mostRecentImage.length) {
                                 [self.mailComposeViewController addAttachmentData:mostRecentImage mimeType:@"image/png" fileName:screenshotFileName];


### PR DESCRIPTION
Also, for better iOS 9 compatibility, the library now uses `UIAlertController` if available since `UIAlertView` is deprecated since iOS 8.