### PR TITLE
Prevent rendering screenshot from causing a crash on iOS 9

### DIFF
--- a/Logging/ARKLogDistributor.m
+++ b/Logging/ARKLogDistributor.m
@@ -244,14 +244,23 @@
 
 - (void)logScreenshot;
 {
-    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
-    UIGraphicsBeginImageContextWithOptions(window.bounds.size, YES, 0.0);
-    [window.layer renderInContext:UIGraphicsGetCurrentContext()];
-    UIImage *screenshot = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
+    UIImage *screenshot = nil;
     
-    NSString *logText = @"Screenshot Logged";
-    [self logWithText:logText image:screenshot type:ARKLogTypeScreenshot userInfo:nil];
+    @try {
+        UIWindow *window = [[UIApplication sharedApplication] keyWindow];
+        UIGraphicsBeginImageContextWithOptions(window.bounds.size, YES, 0.0);
+        [window.layer renderInContext:UIGraphicsGetCurrentContext()];
+        screenshot = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+    }
+    @catch (NSException *exception) {
+        [self logWithType:ARKLogTypeError userInfo:nil format:@"Screenshot capture failed due to %@", exception];
+    }
+    
+    if (screenshot != nil) {
+        NSString *logText = @"Screenshot Logged";
+        [self logWithText:logText image:screenshot type:ARKLogTypeScreenshot userInfo:nil];
+    }
 }
 
 #pragma mark - Protected Methods


### PR DESCRIPTION
Should fix #20. Please review, though do not merge until I've had a chance to test this in-app.

cc @pwesten @EricMuller22 @mthole @steckel