### PR TITLE
add a new dynamic framework target for iOS 8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ before_script:
     - bundle install
 script:
     - xcodebuild -project Aardvark.xcodeproj -scheme Aardvark -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build test
+    - xcodebuild -project Aardvark.xcodeproj -scheme "Aardvark-iOS" -sdk iphonesimulator clean
     - xcodebuild -project Aardvark.xcodeproj -scheme "Aardvark-iOS" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build
     - pod lib lint --verbose --fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ before_script:
     - bundle install
 script:
     - xcodebuild -project Aardvark.xcodeproj -scheme Aardvark -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build test
-    - xcodebuild -project Valet.xcodeproj -scheme "Aardvark-iOS" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build
+    - xcodebuild -project Aardvark.xcodeproj -scheme "Aardvark-iOS" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build
     - pod lib lint --verbose --fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ before_script:
     - bundle install
 script:
     - xcodebuild -project Aardvark.xcodeproj -scheme Aardvark -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build test
+    - xcodebuild -project Valet.xcodeproj -scheme "Valet-iOS" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build
     - pod lib lint --verbose --fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ before_script:
     - bundle install
 script:
     - xcodebuild -project Aardvark.xcodeproj -scheme Aardvark -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build test
-    - xcodebuild -project Aardvark.xcodeproj -scheme "Aardvark-iOS" -sdk iphonesimulator -configuration Release -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build
+    - xcodebuild -project Aardvark.xcodeproj -scheme "Aardvark-iOS" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build
     - pod lib lint --verbose --fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ before_script:
     - bundle install
 script:
     - xcodebuild -project Aardvark.xcodeproj -scheme Aardvark -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build test
-    - xcodebuild -project Aardvark.xcodeproj -scheme "Aardvark-iOS" -sdk iphonesimulator clean
     - xcodebuild -project Aardvark.xcodeproj -scheme "Aardvark-iOS" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build
     - pod lib lint --verbose --fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ before_script:
     - bundle install
 script:
     - xcodebuild -project Aardvark.xcodeproj -scheme Aardvark -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build test
-    - xcodebuild -project Aardvark.xcodeproj -scheme "Aardvark-iOS" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build
+    - xcodebuild -project Aardvark.xcodeproj -scheme "Aardvark-iOS" -sdk iphonesimulator -configuration Release -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build
     - pod lib lint --verbose --fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ before_script:
     - bundle install
 script:
     - xcodebuild -project Aardvark.xcodeproj -scheme Aardvark -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build test
-    - xcodebuild -project Valet.xcodeproj -scheme "Valet-iOS" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build
+    - xcodebuild -project Valet.xcodeproj -scheme "Aardvark-iOS" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build
     - pod lib lint --verbose --fail-fast

--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		4551A2F91BDAD21F00F216D0 /* ARKLogTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EAD1446419E22D080065A1FF /* ARKLogTableViewController.m */; };
 		4551A2FA1BDAD22900F216D0 /* ARKScreenshotViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EAD1447419E22E800065A1FF /* ARKScreenshotViewController.m */; };
 		4551A2FB1BDAD32200F216D0 /* ARKLogObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = EA491AF919E5EAAA00762174 /* ARKLogObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A3031BDAF57D00F216D0 /* ARKLogTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 4551A3011BDAF57D00F216D0 /* ARKLogTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A3041BDAF57D00F216D0 /* ARKLogTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 4551A3011BDAF57D00F216D0 /* ARKLogTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D04D47EA1AB8A09B00A342E9 /* ARKDataArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = D04D47E81AB8A09B00A342E9 /* ARKDataArchive.h */; };
 		D04D47EB1AB8A09B00A342E9 /* ARKDataArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = D04D47E91AB8A09B00A342E9 /* ARKDataArchive.m */; };
 		D04D47ED1AB8A0BA00A342E9 /* ARKDataArchiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D04D47EC1AB8A0BA00A342E9 /* ARKDataArchiveTests.m */; };
@@ -103,6 +105,7 @@
 /* Begin PBXFileReference section */
 		4551A2C21BDACF9000F216D0 /* Aardvark.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Aardvark.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4551A2FC1BDAD40E00F216D0 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Other/Info.plist; sourceTree = "<group>"; };
+		4551A3011BDAF57D00F216D0 /* ARKLogTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKLogTypes.h; sourceTree = "<group>"; };
 		D04D47E81AB8A09B00A342E9 /* ARKDataArchive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARKDataArchive.h; path = Logging/ARKDataArchive.h; sourceTree = "<group>"; };
 		D04D47E91AB8A09B00A342E9 /* ARKDataArchive.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ARKDataArchive.m; path = Logging/ARKDataArchive.m; sourceTree = "<group>"; };
 		D04D47EC1AB8A0BA00A342E9 /* ARKDataArchiveTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ARKDataArchiveTests.m; path = AardvarkTests/ARKDataArchiveTests.m; sourceTree = "<group>"; };
@@ -256,6 +259,7 @@
 			children = (
 				EAD1442419E073FB0065A1FF /* Aardvark.h */,
 				EAD1442619E073FB0065A1FF /* Aardvark.m */,
+				4551A3011BDAF57D00F216D0 /* ARKLogTypes.h */,
 			);
 			path = Aardvark;
 			sourceTree = "<group>";
@@ -372,6 +376,7 @@
 				4551A2F11BDAD1E800F216D0 /* ARKLogDistributor_Protected.h in Headers */,
 				4551A2EA1BDAD1A900F216D0 /* NSURL+ARKAdditions.h in Headers */,
 				4551A2E21BDAD16A00F216D0 /* ARKDefaultLogFormatter.h in Headers */,
+				4551A3041BDAF57D00F216D0 /* ARKLogTypes.h in Headers */,
 				4551A2E91BDAD1A400F216D0 /* NSFileHandle+ARKAdditions.h in Headers */,
 				4551A2E71BDAD19000F216D0 /* ARKBugReporter.h in Headers */,
 				4551A2E61BDAD17E00F216D0 /* ARKDataArchive.h in Headers */,
@@ -395,6 +400,7 @@
 				EAAB389D19E28D5200161A54 /* ARKDefaultLogFormatter.h in Headers */,
 				EAD1447119E22E470065A1FF /* ARKIndividualLogViewController.h in Headers */,
 				EA491AFB19E5EAAA00762174 /* ARKLogObserver.h in Headers */,
+				4551A3031BDAF57D00F216D0 /* ARKLogTypes.h in Headers */,
 				EAAB38A019E28E9B00161A54 /* ARKLogFormatter.h in Headers */,
 				EA61D2311B1648DD00D1AB77 /* module.modulemap in Headers */,
 				EAE2F5741ACA10B4006FFDDC /* ARKLogDistributor_Protected.h in Headers */,

--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -632,7 +632,6 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.Aardvark;
 				PRODUCT_NAME = Aardvark;
 				SKIP_INSTALL = YES;

--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -43,6 +43,10 @@
 		4551A2FB1BDAD32200F216D0 /* ARKLogObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = EA491AF919E5EAAA00762174 /* ARKLogObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4551A3031BDAF57D00F216D0 /* ARKLogTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 4551A3011BDAF57D00F216D0 /* ARKLogTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4551A3041BDAF57D00F216D0 /* ARKLogTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 4551A3011BDAF57D00F216D0 /* ARKLogTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A3091BDAF93A00F216D0 /* ARKLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 4551A3071BDAF93A00F216D0 /* ARKLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A30A1BDAF93A00F216D0 /* ARKLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 4551A3071BDAF93A00F216D0 /* ARKLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A30B1BDAF93A00F216D0 /* ARKLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 4551A3081BDAF93A00F216D0 /* ARKLogging.m */; };
+		4551A30C1BDAF93A00F216D0 /* ARKLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 4551A3081BDAF93A00F216D0 /* ARKLogging.m */; };
 		D04D47EA1AB8A09B00A342E9 /* ARKDataArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = D04D47E81AB8A09B00A342E9 /* ARKDataArchive.h */; };
 		D04D47EB1AB8A09B00A342E9 /* ARKDataArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = D04D47E91AB8A09B00A342E9 /* ARKDataArchive.m */; };
 		D04D47ED1AB8A0BA00A342E9 /* ARKDataArchiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D04D47EC1AB8A0BA00A342E9 /* ARKDataArchiveTests.m */; };
@@ -106,6 +110,8 @@
 		4551A2C21BDACF9000F216D0 /* Aardvark.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Aardvark.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4551A2FC1BDAD40E00F216D0 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Other/Info.plist; sourceTree = "<group>"; };
 		4551A3011BDAF57D00F216D0 /* ARKLogTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKLogTypes.h; sourceTree = "<group>"; };
+		4551A3071BDAF93A00F216D0 /* ARKLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKLogging.h; sourceTree = "<group>"; };
+		4551A3081BDAF93A00F216D0 /* ARKLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKLogging.m; sourceTree = "<group>"; };
 		D04D47E81AB8A09B00A342E9 /* ARKDataArchive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARKDataArchive.h; path = Logging/ARKDataArchive.h; sourceTree = "<group>"; };
 		D04D47E91AB8A09B00A342E9 /* ARKDataArchive.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ARKDataArchive.m; path = Logging/ARKDataArchive.m; sourceTree = "<group>"; };
 		D04D47EC1AB8A0BA00A342E9 /* ARKDataArchiveTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ARKDataArchiveTests.m; path = AardvarkTests/ARKDataArchiveTests.m; sourceTree = "<group>"; };
@@ -260,6 +266,8 @@
 				EAD1442419E073FB0065A1FF /* Aardvark.h */,
 				EAD1442619E073FB0065A1FF /* Aardvark.m */,
 				4551A3011BDAF57D00F216D0 /* ARKLogTypes.h */,
+				4551A3071BDAF93A00F216D0 /* ARKLogging.h */,
+				4551A3081BDAF93A00F216D0 /* ARKLogging.m */,
 			);
 			path = Aardvark;
 			sourceTree = "<group>";
@@ -365,6 +373,7 @@
 				4551A2DC1BDAD13800F216D0 /* ARKEmailBugReporter.h in Headers */,
 				4551A2E01BDAD15E00F216D0 /* ARKLogMessage.h in Headers */,
 				4551A2DE1BDAD15300F216D0 /* ARKLogDistributor.h in Headers */,
+				4551A30A1BDAF93A00F216D0 /* ARKLogging.h in Headers */,
 				4551A2F01BDAD1D900F216D0 /* ARKDataArchive_Testing.h in Headers */,
 				4551A2FB1BDAD32200F216D0 /* ARKLogObserver.h in Headers */,
 				4551A2ED1BDAD1BC00F216D0 /* ARKIndividualLogViewController.h in Headers */,
@@ -399,6 +408,7 @@
 				D04D47FF1AB905C900A342E9 /* NSFileHandle+ARKAdditions.h in Headers */,
 				EAAB389D19E28D5200161A54 /* ARKDefaultLogFormatter.h in Headers */,
 				EAD1447119E22E470065A1FF /* ARKIndividualLogViewController.h in Headers */,
+				4551A3091BDAF93A00F216D0 /* ARKLogging.h in Headers */,
 				EA491AFB19E5EAAA00762174 /* ARKLogObserver.h in Headers */,
 				4551A3031BDAF57D00F216D0 /* ARKLogTypes.h in Headers */,
 				EAAB38A019E28E9B00161A54 /* ARKLogFormatter.h in Headers */,
@@ -544,6 +554,7 @@
 				4551A2DB1BDAD13600F216D0 /* ARKEmailBugReporter.m in Sources */,
 				4551A2F61BDAD21000F216D0 /* UIApplication+ARKAdditions.m in Sources */,
 				4551A2F91BDAD21F00F216D0 /* ARKLogTableViewController.m in Sources */,
+				4551A30C1BDAF93A00F216D0 /* ARKLogging.m in Sources */,
 				4551A2F31BDAD20600F216D0 /* NSFileHandle+ARKAdditions.m in Sources */,
 				4551A2E11BDAD16900F216D0 /* ARKDefaultLogFormatter.m in Sources */,
 				4551A2F41BDAD20A00F216D0 /* NSURL+ARKAdditions.m in Sources */,
@@ -565,6 +576,7 @@
 				EAD1444A19E084C40065A1FF /* ARKLogMessage.m in Sources */,
 				EAD1446019E211250065A1FF /* ARKEmailBugReporter.m in Sources */,
 				D04D47F71AB8FD9000A342E9 /* NSURL+ARKAdditions.m in Sources */,
+				4551A30B1BDAF93A00F216D0 /* ARKLogging.m in Sources */,
 				EAAB389E19E28D5200161A54 /* ARKDefaultLogFormatter.m in Sources */,
 				D04D47EB1AB8A09B00A342E9 /* ARKDataArchive.m in Sources */,
 				D04D48001AB905C900A342E9 /* NSFileHandle+ARKAdditions.m in Sources */,
@@ -620,6 +632,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.Aardvark;
 				PRODUCT_NAME = Aardvark;
 				SKIP_INSTALL = YES;

--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -7,6 +7,40 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4551A2D91BDAD10E00F216D0 /* Aardvark.h in Headers */ = {isa = PBXBuildFile; fileRef = EAD1442419E073FB0065A1FF /* Aardvark.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A2DA1BDAD11B00F216D0 /* Aardvark.m in Sources */ = {isa = PBXBuildFile; fileRef = EAD1442619E073FB0065A1FF /* Aardvark.m */; };
+		4551A2DB1BDAD13600F216D0 /* ARKEmailBugReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = EAD1445E19E211250065A1FF /* ARKEmailBugReporter.m */; };
+		4551A2DC1BDAD13800F216D0 /* ARKEmailBugReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = EAD1445D19E211250065A1FF /* ARKEmailBugReporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A2DD1BDAD15100F216D0 /* ARKLogDistributor.m in Sources */ = {isa = PBXBuildFile; fileRef = EAD1444C19E09EEA0065A1FF /* ARKLogDistributor.m */; };
+		4551A2DE1BDAD15300F216D0 /* ARKLogDistributor.h in Headers */ = {isa = PBXBuildFile; fileRef = EAD1444B19E09EEA0065A1FF /* ARKLogDistributor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A2DF1BDAD15C00F216D0 /* ARKLogMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = EAD1444819E084C40065A1FF /* ARKLogMessage.m */; };
+		4551A2E01BDAD15E00F216D0 /* ARKLogMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = EAD1444719E084C40065A1FF /* ARKLogMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A2E11BDAD16900F216D0 /* ARKDefaultLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = EAAB389C19E28D5200161A54 /* ARKDefaultLogFormatter.m */; };
+		4551A2E21BDAD16A00F216D0 /* ARKDefaultLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = EAAB389B19E28D5200161A54 /* ARKDefaultLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A2E31BDAD17100F216D0 /* ARKLogStore.m in Sources */ = {isa = PBXBuildFile; fileRef = EA7353651A1577200060F54E /* ARKLogStore.m */; };
+		4551A2E41BDAD17200F216D0 /* ARKLogStore.h in Headers */ = {isa = PBXBuildFile; fileRef = EA7353641A1577200060F54E /* ARKLogStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A2E51BDAD17B00F216D0 /* ARKDataArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = D04D47E91AB8A09B00A342E9 /* ARKDataArchive.m */; };
+		4551A2E61BDAD17E00F216D0 /* ARKDataArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = D04D47E81AB8A09B00A342E9 /* ARKDataArchive.h */; };
+		4551A2E71BDAD19000F216D0 /* ARKBugReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = EAAB38A519E298ED00161A54 /* ARKBugReporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A2E81BDAD19E00F216D0 /* ARKLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = EAAB389F19E28DEB00161A54 /* ARKLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A2E91BDAD1A400F216D0 /* NSFileHandle+ARKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D04D47FD1AB905C900A342E9 /* NSFileHandle+ARKAdditions.h */; };
+		4551A2EA1BDAD1A900F216D0 /* NSURL+ARKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D04D47F41AB8FD9000A342E9 /* NSURL+ARKAdditions.h */; };
+		4551A2EB1BDAD1AD00F216D0 /* UIActivityViewController+ARKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = EAD1447C19E22FCF0065A1FF /* UIActivityViewController+ARKAdditions.h */; };
+		4551A2EC1BDAD1B700F216D0 /* UIApplication+ARKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = EA6E218C19E84C1D0097BF4F /* UIApplication+ARKAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A2ED1BDAD1BC00F216D0 /* ARKIndividualLogViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = EAD1446F19E22E470065A1FF /* ARKIndividualLogViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A2EE1BDAD1C200F216D0 /* ARKLogTableViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = EAD1446319E22D080065A1FF /* ARKLogTableViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A2EF1BDAD1D100F216D0 /* ARKScreenshotViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = EAD1447319E22E800065A1FF /* ARKScreenshotViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4551A2F01BDAD1D900F216D0 /* ARKDataArchive_Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = D04D48011AB908DD00A342E9 /* ARKDataArchive_Testing.h */; };
+		4551A2F11BDAD1E800F216D0 /* ARKLogDistributor_Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = EAE2F5731ACA10B4006FFDDC /* ARKLogDistributor_Protected.h */; };
+		4551A2F21BDAD1EB00F216D0 /* AardvarkDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = EAD1444419E0849D0065A1FF /* AardvarkDefines.h */; };
+		4551A2F31BDAD20600F216D0 /* NSFileHandle+ARKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D04D47FE1AB905C900A342E9 /* NSFileHandle+ARKAdditions.m */; };
+		4551A2F41BDAD20A00F216D0 /* NSURL+ARKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D04D47F51AB8FD9000A342E9 /* NSURL+ARKAdditions.m */; };
+		4551A2F51BDAD20D00F216D0 /* UIActivityViewController+ARKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = EAD1447D19E22FCF0065A1FF /* UIActivityViewController+ARKAdditions.m */; };
+		4551A2F61BDAD21000F216D0 /* UIApplication+ARKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = EA6E218D19E84C1D0097BF4F /* UIApplication+ARKAdditions.m */; };
+		4551A2F71BDAD21600F216D0 /* ARKIndividualLogViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EAD1447019E22E470065A1FF /* ARKIndividualLogViewController.m */; };
+		4551A2F91BDAD21F00F216D0 /* ARKLogTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EAD1446419E22D080065A1FF /* ARKLogTableViewController.m */; };
+		4551A2FA1BDAD22900F216D0 /* ARKScreenshotViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EAD1447419E22E800065A1FF /* ARKScreenshotViewController.m */; };
+		4551A2FB1BDAD32200F216D0 /* ARKLogObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = EA491AF919E5EAAA00762174 /* ARKLogObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D04D47EA1AB8A09B00A342E9 /* ARKDataArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = D04D47E81AB8A09B00A342E9 /* ARKDataArchive.h */; };
 		D04D47EB1AB8A09B00A342E9 /* ARKDataArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = D04D47E91AB8A09B00A342E9 /* ARKDataArchive.m */; };
 		D04D47ED1AB8A0BA00A342E9 /* ARKDataArchiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D04D47EC1AB8A0BA00A342E9 /* ARKDataArchiveTests.m */; };
@@ -67,6 +101,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4551A2C21BDACF9000F216D0 /* Aardvark.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Aardvark.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4551A2FC1BDAD40E00F216D0 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Other/Info.plist; sourceTree = "<group>"; };
 		D04D47E81AB8A09B00A342E9 /* ARKDataArchive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARKDataArchive.h; path = Logging/ARKDataArchive.h; sourceTree = "<group>"; };
 		D04D47E91AB8A09B00A342E9 /* ARKDataArchive.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ARKDataArchive.m; path = Logging/ARKDataArchive.m; sourceTree = "<group>"; };
 		D04D47EC1AB8A0BA00A342E9 /* ARKDataArchiveTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ARKDataArchiveTests.m; path = AardvarkTests/ARKDataArchiveTests.m; sourceTree = "<group>"; };
@@ -122,6 +158,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		4551A2BE1BDACF9000F216D0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EAD1441E19E073FB0065A1FF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -203,6 +246,7 @@
 			children = (
 				EAD1442119E073FB0065A1FF /* libAardvark.a */,
 				EAD1442C19E073FB0065A1FF /* AardvarkTests.xctest */,
+				4551A2C21BDACF9000F216D0 /* Aardvark.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -255,6 +299,7 @@
 		EAD1444219E0848B0065A1FF /* Other */ = {
 			isa = PBXGroup;
 			children = (
+				4551A2FC1BDAD40E00F216D0 /* Info.plist */,
 				EA09D3C11A2E6CFA004C1125 /* Tests */,
 				EAD1444419E0849D0065A1FF /* AardvarkDefines.h */,
 				EAD1442F19E073FB0065A1FF /* Tests-Info.plist */,
@@ -307,6 +352,33 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		4551A2BF1BDACF9000F216D0 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4551A2E41BDAD17200F216D0 /* ARKLogStore.h in Headers */,
+				4551A2D91BDAD10E00F216D0 /* Aardvark.h in Headers */,
+				4551A2DC1BDAD13800F216D0 /* ARKEmailBugReporter.h in Headers */,
+				4551A2E01BDAD15E00F216D0 /* ARKLogMessage.h in Headers */,
+				4551A2DE1BDAD15300F216D0 /* ARKLogDistributor.h in Headers */,
+				4551A2F01BDAD1D900F216D0 /* ARKDataArchive_Testing.h in Headers */,
+				4551A2FB1BDAD32200F216D0 /* ARKLogObserver.h in Headers */,
+				4551A2ED1BDAD1BC00F216D0 /* ARKIndividualLogViewController.h in Headers */,
+				4551A2E81BDAD19E00F216D0 /* ARKLogFormatter.h in Headers */,
+				4551A2EB1BDAD1AD00F216D0 /* UIActivityViewController+ARKAdditions.h in Headers */,
+				4551A2EE1BDAD1C200F216D0 /* ARKLogTableViewController.h in Headers */,
+				4551A2EC1BDAD1B700F216D0 /* UIApplication+ARKAdditions.h in Headers */,
+				4551A2F21BDAD1EB00F216D0 /* AardvarkDefines.h in Headers */,
+				4551A2F11BDAD1E800F216D0 /* ARKLogDistributor_Protected.h in Headers */,
+				4551A2EA1BDAD1A900F216D0 /* NSURL+ARKAdditions.h in Headers */,
+				4551A2E21BDAD16A00F216D0 /* ARKDefaultLogFormatter.h in Headers */,
+				4551A2E91BDAD1A400F216D0 /* NSFileHandle+ARKAdditions.h in Headers */,
+				4551A2E71BDAD19000F216D0 /* ARKBugReporter.h in Headers */,
+				4551A2E61BDAD17E00F216D0 /* ARKDataArchive.h in Headers */,
+				4551A2EF1BDAD1D100F216D0 /* ARKScreenshotViewController.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EAD1443F19E084300065A1FF /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -345,6 +417,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		4551A2C11BDACF9000F216D0 /* Aardvark-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4551A2D71BDACF9000F216D0 /* Build configuration list for PBXNativeTarget "Aardvark-iOS" */;
+			buildPhases = (
+				4551A2BD1BDACF9000F216D0 /* Sources */,
+				4551A2BE1BDACF9000F216D0 /* Frameworks */,
+				4551A2BF1BDACF9000F216D0 /* Headers */,
+				4551A2C01BDACF9000F216D0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Aardvark-iOS";
+			productName = "Aardvark-iOS";
+			productReference = 4551A2C21BDACF9000F216D0 /* Aardvark.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		EAD1442019E073FB0065A1FF /* Aardvark */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = EAD1443219E073FB0065A1FF /* Build configuration list for PBXNativeTarget "Aardvark" */;
@@ -391,6 +481,9 @@
 				LastUpgradeCheck = 0600;
 				ORGANIZATIONNAME = "Square, Inc.";
 				TargetAttributes = {
+					4551A2C11BDACF9000F216D0 = {
+						CreatedOnToolsVersion = 7.1;
+					};
 					EAD1442019E073FB0065A1FF = {
 						CreatedOnToolsVersion = 6.0.1;
 					};
@@ -413,11 +506,19 @@
 			targets = (
 				EAD1442019E073FB0065A1FF /* Aardvark */,
 				EAD1442B19E073FB0065A1FF /* AardvarkTests */,
+				4551A2C11BDACF9000F216D0 /* Aardvark-iOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		4551A2C01BDACF9000F216D0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EAD1442A19E073FB0065A1FF /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -428,6 +529,27 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4551A2BD1BDACF9000F216D0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4551A2DA1BDAD11B00F216D0 /* Aardvark.m in Sources */,
+				4551A2E31BDAD17100F216D0 /* ARKLogStore.m in Sources */,
+				4551A2DB1BDAD13600F216D0 /* ARKEmailBugReporter.m in Sources */,
+				4551A2F61BDAD21000F216D0 /* UIApplication+ARKAdditions.m in Sources */,
+				4551A2F91BDAD21F00F216D0 /* ARKLogTableViewController.m in Sources */,
+				4551A2F31BDAD20600F216D0 /* NSFileHandle+ARKAdditions.m in Sources */,
+				4551A2E11BDAD16900F216D0 /* ARKDefaultLogFormatter.m in Sources */,
+				4551A2F41BDAD20A00F216D0 /* NSURL+ARKAdditions.m in Sources */,
+				4551A2F51BDAD20D00F216D0 /* UIActivityViewController+ARKAdditions.m in Sources */,
+				4551A2DD1BDAD15100F216D0 /* ARKLogDistributor.m in Sources */,
+				4551A2DF1BDAD15C00F216D0 /* ARKLogMessage.m in Sources */,
+				4551A2F71BDAD21600F216D0 /* ARKIndividualLogViewController.m in Sources */,
+				4551A2E51BDAD17B00F216D0 /* ARKDataArchive.m in Sources */,
+				4551A2FA1BDAD22900F216D0 /* ARKScreenshotViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EAD1441D19E073FB0065A1FF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -476,6 +598,56 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		4551A2D31BDACF9000F216D0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Other/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.Aardvark;
+				PRODUCT_NAME = Aardvark;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		4551A2D41BDACF9000F216D0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Other/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.Aardvark;
+				PRODUCT_NAME = Aardvark;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		EAD1443019E073FB0065A1FF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -581,10 +753,6 @@
 		EAD1443619E073FB0065A1FF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -604,10 +772,6 @@
 		EAD1443719E073FB0065A1FF /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = "AardvarkTests/Tests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (
@@ -623,6 +787,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		4551A2D71BDACF9000F216D0 /* Build configuration list for PBXNativeTarget "Aardvark-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4551A2D31BDACF9000F216D0 /* Debug */,
+				4551A2D41BDACF9000F216D0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		EAD1441C19E073FB0065A1FF /* Build configuration list for PBXProject "Aardvark" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Aardvark.xcodeproj/xcshareddata/xcschemes/Aardvark-iOS.xcscheme
+++ b/Aardvark.xcodeproj/xcshareddata/xcschemes/Aardvark-iOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4551A2C11BDACF9000F216D0"
+               BuildableName = "Aardvark.framework"
+               BlueprintName = "Aardvark-iOS"
+               ReferencedContainer = "container:Aardvark.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4551A2CA1BDACF9000F216D0"
+               BuildableName = "Aardvark-iOSTests.xctest"
+               BlueprintName = "Aardvark-iOSTests"
+               ReferencedContainer = "container:Aardvark.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4551A2C11BDACF9000F216D0"
+            BuildableName = "Aardvark.framework"
+            BlueprintName = "Aardvark-iOS"
+            ReferencedContainer = "container:Aardvark.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4551A2C11BDACF9000F216D0"
+            BuildableName = "Aardvark.framework"
+            BlueprintName = "Aardvark-iOS"
+            ReferencedContainer = "container:Aardvark.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4551A2C11BDACF9000F216D0"
+            BuildableName = "Aardvark.framework"
+            BlueprintName = "Aardvark-iOS"
+            ReferencedContainer = "container:Aardvark.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Aardvark/ARKLogTypes.h
+++ b/Aardvark/ARKLogTypes.h
@@ -20,6 +20,7 @@
 
 #import <UIKit/UIKit.h>
 
+
 typedef NS_ENUM(NSUInteger, ARKLogType) {
     /// Default log type.
     ARKLogTypeDefault,

--- a/Aardvark/ARKLogTypes.h
+++ b/Aardvark/ARKLogTypes.h
@@ -1,0 +1,32 @@
+//
+//  ARKLogTypes.h
+//  Aardvark
+//
+//  Created by Evan Kimia on 10/23/15.
+//  Copyright 2015 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <UIKit/UIKit.h>
+
+typedef NS_ENUM(NSUInteger, ARKLogType) {
+    /// Default log type.
+    ARKLogTypeDefault,
+    /// Marks the beginning or end of a task.
+    ARKLogTypeSeparator,
+    /// Marks that the log represents an error.
+    ARKLogTypeError,
+    /// Marks a log that has a screenshot attached.
+    ARKLogTypeScreenshot,
+};

--- a/Aardvark/ARKLogging.h
+++ b/Aardvark/ARKLogging.h
@@ -1,5 +1,5 @@
 //
-//  ARKLogMessage.h
+//  ARKLogging.h
 //  Aardvark
 //
 //  Created by Dan Federman on 10/4/14.
@@ -18,25 +18,14 @@
 //  limitations under the License.
 //
 
-#import <Aardvark/ARKLogging.h>
+#import <UIKit/UIKit.h>
+#import <Aardvark/ARKLogTypes.h>
 
+/// Logs a log with default type to the default log distributor.
+OBJC_EXTERN void ARKLog(NSString * __nonnull format, ...) NS_FORMAT_FUNCTION(1,2);
 
-NS_ASSUME_NONNULL_BEGIN
+/// Logs a log with customized type and userInfo to the default log distributor.
+OBJC_EXTERN void ARKLogWithType(ARKLogType type, NSDictionary * __nullable userInfo, NSString * __nonnull format, ...) NS_FORMAT_FUNCTION(3,4);
 
-
-@interface ARKLogMessage : NSObject <NSCopying, NSSecureCoding>
-
-- (instancetype)initWithText:(NSString *)text image:(nullable UIImage *)image type:(ARKLogType)type userInfo:(nullable NSDictionary *)userInfo;
-
-@property (nonatomic, copy, readonly) NSDate *creationDate;
-@property (nonatomic, copy, readonly) NSString *text;
-@property (nonatomic, readonly) UIImage *image;
-@property (nonatomic, readonly) ARKLogType type;
-
-/// Arbitrary information used by ARKLogBlocks. This data is not persisted
-@property (nonatomic, copy, readonly) NSDictionary *userInfo;
-
-@end
-
-
-NS_ASSUME_NONNULL_END
+/// Logs a screenshot to the default log distributor.
+OBJC_EXTERN void ARKLogScreenshot();

--- a/Aardvark/ARKLogging.m
+++ b/Aardvark/ARKLogging.m
@@ -22,6 +22,7 @@
 #import "ARKLogDistributor.h"
 
 
+
 void ARKLog(NSString *format, ...)
 {
     va_list argList;

--- a/Aardvark/ARKLogging.m
+++ b/Aardvark/ARKLogging.m
@@ -21,6 +21,7 @@
 #import "ARKLogging.h"
 #import "ARKLogDistributor.h"
 
+
 void ARKLog(NSString *format, ...)
 {
     va_list argList;

--- a/Aardvark/ARKLogging.m
+++ b/Aardvark/ARKLogging.m
@@ -1,0 +1,43 @@
+//
+//  ARKLogging.m
+//  Aardvark
+//
+//  Created by Dan Federman on 10/4/14.
+//  Copyright 2014 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "ARKLogging.h"
+#import "ARKLogDistributor.h"
+
+void ARKLog(NSString *format, ...)
+{
+    va_list argList;
+    va_start(argList, format);
+    [[ARKLogDistributor defaultDistributor] logWithFormat:format arguments:argList];
+    va_end(argList);
+}
+
+void ARKLogWithType(ARKLogType type, NSDictionary *userInfo, NSString *format, ...)
+{
+    va_list argList;
+    va_start(argList, format);
+    [[ARKLogDistributor defaultDistributor] logWithType:type userInfo:userInfo format:format arguments:argList];
+    va_end(argList);
+}
+
+void ARKLogScreenshot()
+{
+    [[ARKLogDistributor defaultDistributor] logScreenshot];
+}

--- a/Aardvark/Aardvark.h
+++ b/Aardvark/Aardvark.h
@@ -21,20 +21,10 @@
 #import <UIKit/UIKit.h>
 
 
-typedef NS_ENUM(NSUInteger, ARKLogType) {
-    /// Default log type.
-    ARKLogTypeDefault,
-    /// Marks the beginning or end of a task.
-    ARKLogTypeSeparator,
-    /// Marks that the log represents an error.
-    ARKLogTypeError,
-    /// Marks a log that has a screenshot attached.
-    ARKLogTypeScreenshot,
-};
-
+#import <Aardvark/ARKLogTypes.h>
 
 /// Logs a log with default type to the default log distributor.
-OBJC_EXTERN void  ARKLog(NSString * __nonnull format, ...) NS_FORMAT_FUNCTION(1,2);
+OBJC_EXTERN void ARKLog(NSString * __nonnull format, ...) NS_FORMAT_FUNCTION(1,2);
 
 /// Logs a log with customized type and userInfo to the default log distributor.
 OBJC_EXTERN void ARKLogWithType(ARKLogType type, NSDictionary * __nullable userInfo, NSString * __nonnull format, ...) NS_FORMAT_FUNCTION(3,4);

--- a/Aardvark/Aardvark.h
+++ b/Aardvark/Aardvark.h
@@ -20,20 +20,6 @@
 
 #import <UIKit/UIKit.h>
 
-#import <Aardvark/ARKBugReporter.h>
-#import <Aardvark/ARKEmailBugReporter.h>
-
-
-//! Project version number for Aardvark-iOS.
-FOUNDATION_EXPORT double Aardvark_iOSVersionNumber;
-
-//! Project version string for Aardvark-iOS.
-FOUNDATION_EXPORT const unsigned char Aardvark_iOSVersionString[];
-
-
-NS_ASSUME_NONNULL_BEGIN
-
-
 typedef NS_ENUM(NSUInteger, ARKLogType) {
     /// Default log type.
     ARKLogTypeDefault,
@@ -45,15 +31,36 @@ typedef NS_ENUM(NSUInteger, ARKLogType) {
     ARKLogTypeScreenshot,
 };
 
-
 /// Logs a log with default type to the default log distributor.
-OBJC_EXTERN void ARKLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2);
+OBJC_EXTERN void  ARKLog(NSString * __nonnull format, ...) NS_FORMAT_FUNCTION(1,2);
 
 /// Logs a log with customized type and userInfo to the default log distributor.
-OBJC_EXTERN void ARKLogWithType(ARKLogType type, NSDictionary * __nullable userInfo, NSString *format, ...) NS_FORMAT_FUNCTION(3,4);
+OBJC_EXTERN void ARKLogWithType(ARKLogType type, NSDictionary * __nullable userInfo, NSString * __nonnull format, ...) NS_FORMAT_FUNCTION(3,4);
 
 /// Logs a screenshot to the default log distributor.
 OBJC_EXTERN void ARKLogScreenshot();
+
+#import <Aardvark/ARKLogStore.h>
+#import <Aardvark/ARKBugReporter.h>
+#import <Aardvark/ARKDefaultLogFormatter.h>
+#import <Aardvark/ARKEmailBugReporter.h>
+#import <Aardvark/ARKIndividualLogViewController.h>
+#import <Aardvark/ARKLogDistributor.h>
+#import <Aardvark/ARKLogFormatter.h>
+#import <Aardvark/ARKLogMessage.h>
+#import <Aardvark/ARKLogObserver.h>
+#import <Aardvark/ARKLogTableViewController.h>
+#import <Aardvark/ARKScreenshotViewController.h>
+#import <Aardvark/UIApplication+ARKAdditions.h>
+
+
+//! Project version number for Aardvark-iOS.
+FOUNDATION_EXPORT double Aardvark_iOSVersionNumber;
+
+//! Project version string for Aardvark-iOS.
+FOUNDATION_EXPORT const unsigned char Aardvark_iOSVersionString[];
+
+NS_ASSUME_NONNULL_BEGIN
 
 
 @interface Aardvark : NSObject

--- a/Aardvark/Aardvark.h
+++ b/Aardvark/Aardvark.h
@@ -22,17 +22,6 @@
 
 
 #import <Aardvark/ARKLogTypes.h>
-
-/// Logs a log with default type to the default log distributor.
-OBJC_EXTERN void ARKLog(NSString * __nonnull format, ...) NS_FORMAT_FUNCTION(1,2);
-
-/// Logs a log with customized type and userInfo to the default log distributor.
-OBJC_EXTERN void ARKLogWithType(ARKLogType type, NSDictionary * __nullable userInfo, NSString * __nonnull format, ...) NS_FORMAT_FUNCTION(3,4);
-
-/// Logs a screenshot to the default log distributor.
-OBJC_EXTERN void ARKLogScreenshot();
-
-
 #import <Aardvark/ARKBugReporter.h>
 #import <Aardvark/ARKDefaultLogFormatter.h>
 #import <Aardvark/ARKEmailBugReporter.h>

--- a/Aardvark/Aardvark.h
+++ b/Aardvark/Aardvark.h
@@ -20,6 +20,7 @@
 
 #import <UIKit/UIKit.h>
 
+
 typedef NS_ENUM(NSUInteger, ARKLogType) {
     /// Default log type.
     ARKLogTypeDefault,
@@ -31,6 +32,7 @@ typedef NS_ENUM(NSUInteger, ARKLogType) {
     ARKLogTypeScreenshot,
 };
 
+
 /// Logs a log with default type to the default log distributor.
 OBJC_EXTERN void  ARKLog(NSString * __nonnull format, ...) NS_FORMAT_FUNCTION(1,2);
 
@@ -39,6 +41,7 @@ OBJC_EXTERN void ARKLogWithType(ARKLogType type, NSDictionary * __nullable userI
 
 /// Logs a screenshot to the default log distributor.
 OBJC_EXTERN void ARKLogScreenshot();
+
 
 #import <Aardvark/ARKBugReporter.h>
 #import <Aardvark/ARKDefaultLogFormatter.h>
@@ -59,6 +62,7 @@ FOUNDATION_EXPORT double Aardvark_iOSVersionNumber;
 
 //! Project version string for Aardvark-iOS.
 FOUNDATION_EXPORT const unsigned char Aardvark_iOSVersionString[];
+
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Aardvark/Aardvark.h
+++ b/Aardvark/Aardvark.h
@@ -22,6 +22,7 @@
 
 
 #import <Aardvark/ARKLogTypes.h>
+
 #import <Aardvark/ARKBugReporter.h>
 #import <Aardvark/ARKDefaultLogFormatter.h>
 #import <Aardvark/ARKEmailBugReporter.h>

--- a/Aardvark/Aardvark.h
+++ b/Aardvark/Aardvark.h
@@ -40,7 +40,6 @@ OBJC_EXTERN void ARKLogWithType(ARKLogType type, NSDictionary * __nullable userI
 /// Logs a screenshot to the default log distributor.
 OBJC_EXTERN void ARKLogScreenshot();
 
-#import <Aardvark/ARKLogStore.h>
 #import <Aardvark/ARKBugReporter.h>
 #import <Aardvark/ARKDefaultLogFormatter.h>
 #import <Aardvark/ARKEmailBugReporter.h>
@@ -49,6 +48,7 @@ OBJC_EXTERN void ARKLogScreenshot();
 #import <Aardvark/ARKLogFormatter.h>
 #import <Aardvark/ARKLogMessage.h>
 #import <Aardvark/ARKLogObserver.h>
+#import <Aardvark/ARKLogStore.h>
 #import <Aardvark/ARKLogTableViewController.h>
 #import <Aardvark/ARKScreenshotViewController.h>
 #import <Aardvark/UIApplication+ARKAdditions.h>

--- a/Aardvark/Aardvark.h
+++ b/Aardvark/Aardvark.h
@@ -18,8 +18,17 @@
 //  limitations under the License.
 //
 
+#import <UIKit/UIKit.h>
+
 #import <Aardvark/ARKBugReporter.h>
 #import <Aardvark/ARKEmailBugReporter.h>
+
+
+//! Project version number for Aardvark-iOS.
+FOUNDATION_EXPORT double Aardvark_iOSVersionNumber;
+
+//! Project version string for Aardvark-iOS.
+FOUNDATION_EXPORT const unsigned char Aardvark_iOSVersionString[];
 
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Aardvark/Aardvark.m
+++ b/Aardvark/Aardvark.m
@@ -27,29 +27,6 @@
 #import "ARKLogStore.h"
 #import "UIApplication+ARKAdditions.h"
 
-
-void ARKLog(NSString *format, ...)
-{
-    va_list argList;
-    va_start(argList, format);
-    [[ARKLogDistributor defaultDistributor] logWithFormat:format arguments:argList];
-    va_end(argList);
-}
-
-void ARKLogWithType(ARKLogType type, NSDictionary *userInfo, NSString *format, ...)
-{
-    va_list argList;
-    va_start(argList, format);
-    [[ARKLogDistributor defaultDistributor] logWithType:type userInfo:userInfo format:format arguments:argList];
-    va_end(argList);
-}
-
-void ARKLogScreenshot()
-{
-    [[ARKLogDistributor defaultDistributor] logScreenshot];
-}
-
-
 @implementation Aardvark
 
 #pragma mark - Class Methods

--- a/Logging/ARKLogDistributor.h
+++ b/Logging/ARKLogDistributor.h
@@ -18,7 +18,7 @@
 //  limitations under the License.
 //
 
-#import <Aardvark/Aardvark.h>
+#import <Aardvark/ARKLogging.h>
 
 
 @protocol ARKLogObserver;

--- a/Logging/ARKLogDistributor.h
+++ b/Logging/ARKLogDistributor.h
@@ -19,9 +19,8 @@
 //
 
 #import <Aardvark/ARKLogging.h>
+#import <Aardvark/ARKLogObserver.h>
 
-
-@protocol ARKLogObserver;
 @class ARKLogMessage;
 @class ARKLogStore;
 

--- a/Logging/ARKLogDistributor.m
+++ b/Logging/ARKLogDistributor.m
@@ -23,7 +23,6 @@
 
 #import "AardvarkDefines.h"
 #import "ARKLogMessage.h"
-#import "ARKLogObserver.h"
 #import "ARKLogStore.h"
 
 

--- a/Other/Info.plist
+++ b/Other/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>


### PR DESCRIPTION
* Adds a new target to generate a dynamic framework
* removed a framework search path in the test target which was pointed to an non existent system directory to get rid of a warning