### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,19 +1,19 @@
-###Sign the CLA
+### Sign the CLA
 
 All contributors to your PR must sign our [Individual Contributor License Agreement (CLA)](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1). The CLA is a short form that ensures that you are eligible to contribute.
 
-###One issue or bug per Pull Request
+### One issue or bug per Pull Request
 
 Keep your Pull Requests small. Small PRs are easier to reason about which makes them significantly more likely to get merged.
 
-###Issues before features
+### Issues before features
 
 If you want to add a feature, please file an [Issue](issues) first. An Issue gives us the opportunity to discuss the requirements and implications of a feature with you before you start writing code.
 
-###Backwards compatibility
+### Backwards compatibility
 
 Respect the minimum deployment target. If you are adding code that uses new APIs, make sure to prevent older clients from crashing or misbehaving. Our CI runs against our minimum deployment targets, so you will not get a green build unless your code is backwards compatible. 
 
-###Forwards compatibility
+### Forwards compatibility
 
 Please do not write new code using deprecated APIs.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Aardvark is a library that makes it dead simple to create actionable bug reports
 
 There are only three steps to get Aardvark logging and bug reporting up and running.
 
-###1) Install Aardvark.
+### 1) Install Aardvark.
 
 #### Using [CocoaPods](https://cocoapods.org)
 
@@ -32,7 +32,7 @@ github "Square/Aardvark"
 
 Or manually checkout the submodule with `git submodule add git@github.com:Square/Aardvark.git`, drag Aardvark.xcodeproj to your project, and add Aardvark as a build dependency.
 
-###2) Setup email bug reporting with a single method call
+### 2) Setup email bug reporting with a single method call
 It is best to do this when you load your application’s UI.
 
 In Swift:
@@ -47,7 +47,7 @@ In Objective-C:
 [Aardvark addDefaultBugReportingGestureWithEmailBugReporterWithRecipient:]
 ```
 
-###3) Replace calls to `print` with `log`.
+### 3) Replace calls to `print` with `log`.
 In Objective-C, replace calls to `NSLog` with `ARKLog`.
 
 ## Reporting Bugs


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
