### PR TITLE
Include system build version in email body

### DIFF
--- a/Aardvark/ARKEmailBugReporter.m
+++ b/Aardvark/ARKEmailBugReporter.m
@@ -170,7 +170,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
                            @"2. \n"
                            @"3. \n"
                            @"\n"
-                           @"System version: %@", [[UIDevice currentDevice] systemVersion]];
+                           @"System: %@", [[NSProcessInfo processInfo] operatingSystemVersionString]];
     
     _logFormatter = [ARKDefaultLogFormatter new];
     _numberOfRecentErrorLogsToIncludeInEmailBodyWhenAttachmentsAreAvailable = 3;


### PR DESCRIPTION
When bugs are reported from a beta OS, the prefilled email body looked like:

> System Version: 11.0

It's useful to be able to determine which beta/build of the OS, and this PR updates it to be:

> System: Version 11.0 (Build 15A5361a)
