### PR TITLE
Use the topmost presented view controller for displaying bug title capture alert

### DIFF
--- a/Aardvark.podspec
+++ b/Aardvark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Aardvark'
-  s.version  = '3.1.0'
+  s.version  = '3.1.1'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark is a library that makes it dead simple to create actionable bug reports.'
   s.homepage = 'https://github.com/square/Aardvark'

--- a/Aardvark/ARKEmailBugReporter.m
+++ b/Aardvark/ARKEmailBugReporter.m
@@ -267,8 +267,10 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
         [self _configureAlertTextfield:textField];
     }];
     
-    UIViewController *const rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
-    UIViewController *const viewControllerToPresentAlertController = rootViewController.presentedViewController ?: rootViewController;
+    UIViewController *viewControllerToPresentAlertController = [UIApplication sharedApplication].keyWindow.rootViewController;
+    while (viewControllerToPresentAlertController.presentedViewController != nil) {
+        viewControllerToPresentAlertController = viewControllerToPresentAlertController.presentedViewController;
+    }
     [viewControllerToPresentAlertController presentViewController:alertController animated:YES completion:NULL];
 
 }


### PR DESCRIPTION
This fixes a bug in which the bug title capture alert wouldn't be shown (and thus email bug reporting flow failed) when an app has more than one level of presented view controllers.