### PR TITLE
Add email attachment delegate

### DIFF
--- a/Aardvark.podspec
+++ b/Aardvark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Aardvark'
-  s.version  = '3.2.0'
+  s.version  = '3.3.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark is a library that makes it dead simple to create actionable bug reports.'
   s.homepage = 'https://github.com/square/Aardvark'

--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3DED97142006D35B007FC95C /* ARKEmailAttachment.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DED97122006D35B007FC95C /* ARKEmailAttachment.h */; };
+		3DED97152006D35B007FC95C /* ARKEmailAttachment.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DED97132006D35B007FC95C /* ARKEmailAttachment.m */; };
 		4551A2D91BDAD10E00F216D0 /* Aardvark.h in Headers */ = {isa = PBXBuildFile; fileRef = EAD1442419E073FB0065A1FF /* Aardvark.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4551A30A1BDAF93A00F216D0 /* ARKScreenshotLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 4551A3071BDAF93A00F216D0 /* ARKScreenshotLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA3C1D961D934A210048C4CD /* CoreAardvark.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAF2FEA01D47172400931663 /* CoreAardvark.framework */; };
@@ -92,6 +94,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3DED97122006D35B007FC95C /* ARKEmailAttachment.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARKEmailAttachment.h; path = Aardvark/ARKEmailAttachment.h; sourceTree = "<group>"; };
+		3DED97132006D35B007FC95C /* ARKEmailAttachment.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ARKEmailAttachment.m; path = Aardvark/ARKEmailAttachment.m; sourceTree = "<group>"; };
 		4551A2C21BDACF9000F216D0 /* Aardvark.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Aardvark.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4551A3071BDAF93A00F216D0 /* ARKScreenshotLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKScreenshotLogging.h; sourceTree = "<group>"; };
 		4551A3081BDAF93A00F216D0 /* ARKScreenshotLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKScreenshotLogging.m; sourceTree = "<group>"; };
@@ -293,6 +297,8 @@
 				EA98B9331D4BEB6E00B3A390 /* ARKEmailBugReporter_Testing.h */,
 				EA98B9341D4BEB6E00B3A390 /* ARKEmailBugReporter.h */,
 				EA98B9351D4BEB6E00B3A390 /* ARKEmailBugReporter.m */,
+				3DED97122006D35B007FC95C /* ARKEmailAttachment.h */,
+				3DED97132006D35B007FC95C /* ARKEmailAttachment.m */,
 				EA98B9361D4BEB6E00B3A390 /* ARKLogFormatter.h */,
 			);
 			name = "Bug Reporting";
@@ -405,6 +411,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4551A2D91BDAD10E00F216D0 /* Aardvark.h in Headers */,
+				3DED97142006D35B007FC95C /* ARKEmailAttachment.h in Headers */,
 				EA98B9401D4BEB6E00B3A390 /* ARKEmailBugReporter.h in Headers */,
 				4551A30A1BDAF93A00F216D0 /* ARKScreenshotLogging.h in Headers */,
 				EA98B9441D4BEB6E00B3A390 /* ARKLogFormatter.h in Headers */,
@@ -610,6 +617,7 @@
 				EA98B9531D4BF43400B3A390 /* ARKScreenshotLogging.m in Sources */,
 				EA98B93C1D4BEB6E00B3A390 /* ARKDefaultLogFormatter.m in Sources */,
 				EA98B92B1D4BEB6000B3A390 /* UIActivityViewController+ARKAdditions.m in Sources */,
+				3DED97152006D35B007FC95C /* ARKEmailAttachment.m in Sources */,
 				EA98B9421D4BEB6E00B3A390 /* ARKEmailBugReporter.m in Sources */,
 				EA98B9121D4BEB3D00B3A390 /* ARKLogDistributor+UIAdditions.m in Sources */,
 				EA98B94E1D4BF37000B3A390 /* UIApplication+ARKAdditions.swift in Sources */,

--- a/Aardvark/ARKEmailAttachment.h
+++ b/Aardvark/ARKEmailAttachment.h
@@ -29,12 +29,12 @@
 + (nonnull instancetype)new NS_UNAVAILABLE;
 
 /// File name (including extension) to use when attaching to the email. This does not need to be unique among attachments, but should not be empty.
-@property (nonnull, nonatomic) NSString *fileName;
+@property (nonnull, nonatomic, copy, readonly) NSString *fileName;
 
 /// Contents of the attachment. Attachments with empty data will be dropped.
-@property (nonnull, nonatomic) NSData *data;
+@property (nonnull, nonatomic, copy, readonly) NSData *data;
 
 /// MIME type of `data` property. MIME types are as specified by the IANA: http://www.iana.org/assignments/media-types/
-@property (nonnull, nonatomic) NSString *dataMIMEType;
+@property (nonnull, nonatomic, copy, readonly) NSString *dataMIMEType;
 
 @end

--- a/Aardvark/ARKEmailAttachment.h
+++ b/Aardvark/ARKEmailAttachment.h
@@ -1,0 +1,40 @@
+//
+//  ARKEmailAttachment.h
+//  Aardvark
+//
+//  Created by Nick Entin on 1/10/18.
+//  Copyright 2018 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+
+@interface ARKEmailAttachment : NSObject
+
+- (nonnull instancetype)initWithFileName:(nonnull NSString *)fileName data:(nonnull NSData *)data dataMIMEType:(nonnull NSString *)dataMIMEType;
+
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+
+/// File name (including extension) to use when attaching to the email. This does not need to be unique among attachments, but should not be empty.
+@property (nonnull, nonatomic) NSString *fileName;
+
+/// Contents of the attachment. Attachments with empty data will be dropped.
+@property (nonnull, nonatomic) NSData *data;
+
+/// MIME type of `data` property. MIME types are as specified by the IANA: http://www.iana.org/assignments/media-types/
+@property (nonnull, nonatomic) NSString *dataMIMEType;
+
+@end

--- a/Aardvark/ARKEmailAttachment.m
+++ b/Aardvark/ARKEmailAttachment.m
@@ -1,0 +1,37 @@
+//
+//  ARKEmailAttachment.m
+//  Aardvark
+//
+//  Created by Nick Entin on 1/10/18.
+//  Copyright 2018 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "ARKEmailAttachment.h"
+
+
+@implementation ARKEmailAttachment
+
+- (instancetype)initWithFileName:(NSString *)fileName data:(NSData *)data dataMIMEType:(NSString *)dataMIMEType;
+{
+    self = [super init];
+    
+    _fileName = fileName;
+    _data = data;
+    _dataMIMEType = dataMIMEType;
+    
+    return self;
+}
+
+@end

--- a/Aardvark/ARKEmailAttachment.m
+++ b/Aardvark/ARKEmailAttachment.m
@@ -27,9 +27,9 @@
 {
     self = [super init];
     
-    _fileName = fileName;
-    _data = data;
-    _dataMIMEType = dataMIMEType;
+    _fileName = [fileName copy];
+    _data = [data copy];
+    _dataMIMEType = [dataMIMEType copy];
     
     return self;
 }

--- a/Aardvark/ARKEmailBugReporter.h
+++ b/Aardvark/ARKEmailBugReporter.h
@@ -39,6 +39,37 @@
 @end
 
 
+@interface ARKEmailAttachment : NSObject
+
+- (nonnull instancetype)initWithFileName:(nonnull NSString *)fileName data:(nonnull NSData *)data dataMIMEType:(nonnull NSString *)dataMIMEType;
+
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+
+@property (nonnull, nonatomic) NSString *fileName;
+
+@property (nonnull, nonatomic) NSData *data;
+
+@property (nonnull, nonatomic) NSString *dataMIMEType;
+
+@end
+
+
+@protocol ARKEmailBugReporterEmailAttachmentAdditionsDelegate <NSObject>
+
+@optional
+
+/// Called on the main thread when a bug is filed. When not implemented, all log stores added to the bug reporter will be included.
+- (BOOL)bugReporter:(nonnull ARKEmailBugReporter *)emailBugReporter shouldIncludeLogStoreInBugReport:(nonnull ARKLogStore *)logStore;
+
+@optional
+
+/// Called on the main thread when a bug is filed. The attachments in the returned array will be attached to the bug report email.
+- (nullable NSArray<ARKEmailAttachment *> *)additionalEmailAttachmentsForEmailBugReporter:(nonnull ARKEmailBugReporter *)emailBugReporter;
+
+@end
+
+
 /// Composes a bug report that is sent via email.
 @interface ARKEmailBugReporter : NSObject <ARKBugReporter>
 
@@ -55,6 +86,9 @@
 
 /// The email body delegate, responsible for providing key/value pairs to include in the bug report at the time the bug is filed.
 @property (nullable, nonatomic, weak) id <ARKEmailBugReporterEmailBodyAdditionsDelegate> emailBodyAdditionsDelegate;
+
+/// The email attachment delegate, responsible for providing additional attachments and filtering which log stores to include in the bug report at the time the bug is filed.
+@property (nullable, nonatomic, weak) id <ARKEmailBugReporterEmailAttachmentAdditionsDelegate> emailAttachmentAdditionsDelegate;
 
 /// The formatter used to prepare the log for entry into an email. Defaults to a vanilla instance of ARKDefaultLogFormatter.
 @property (nonnull, nonatomic) id <ARKLogFormatter> logFormatter;

--- a/Aardvark/ARKEmailBugReporter.h
+++ b/Aardvark/ARKEmailBugReporter.h
@@ -45,7 +45,7 @@
 @required
 
 /// Called on the main thread when a bug is filed. When not implemented, all log stores added to the bug reporter will be included.
-- (BOOL)bugReporter:(nonnull ARKEmailBugReporter *)emailBugReporter shouldIncludeLogStoreInBugReport:(nonnull ARKLogStore *)logStore;
+- (BOOL)emailBugReporter:(nonnull ARKEmailBugReporter *)emailBugReporter shouldIncludeLogStoreInBugReport:(nonnull ARKLogStore *)logStore;
 
 /// Called on the main thread when a bug is filed. The attachments in the returned array will be attached to the bug report email.
 - (nullable NSArray<ARKEmailAttachment *> *)additionalEmailAttachmentsForEmailBugReporter:(nonnull ARKEmailBugReporter *)emailBugReporter;

--- a/Aardvark/ARKEmailBugReporter.h
+++ b/Aardvark/ARKEmailBugReporter.h
@@ -24,6 +24,7 @@
 #import <Aardvark/ARKBugReporter.h>
 
 
+@class ARKEmailAttachment;
 @class ARKEmailBugReporter;
 @class ARKLogStore;
 @protocol ARKLogFormatter;
@@ -39,30 +40,12 @@
 @end
 
 
-@interface ARKEmailAttachment : NSObject
-
-- (nonnull instancetype)initWithFileName:(nonnull NSString *)fileName data:(nonnull NSData *)data dataMIMEType:(nonnull NSString *)dataMIMEType;
-
-- (nonnull instancetype)init NS_UNAVAILABLE;
-+ (nonnull instancetype)new NS_UNAVAILABLE;
-
-@property (nonnull, nonatomic) NSString *fileName;
-
-@property (nonnull, nonatomic) NSData *data;
-
-@property (nonnull, nonatomic) NSString *dataMIMEType;
-
-@end
-
-
 @protocol ARKEmailBugReporterEmailAttachmentAdditionsDelegate <NSObject>
 
-@optional
+@required
 
 /// Called on the main thread when a bug is filed. When not implemented, all log stores added to the bug reporter will be included.
 - (BOOL)bugReporter:(nonnull ARKEmailBugReporter *)emailBugReporter shouldIncludeLogStoreInBugReport:(nonnull ARKLogStore *)logStore;
-
-@optional
 
 /// Called on the main thread when a bug is filed. The attachments in the returned array will be attached to the bug report email.
 - (nullable NSArray<ARKEmailAttachment *> *)additionalEmailAttachmentsForEmailBugReporter:(nonnull ARKEmailBugReporter *)emailBugReporter;

--- a/Aardvark/ARKEmailBugReporter.m
+++ b/Aardvark/ARKEmailBugReporter.m
@@ -395,17 +395,16 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 {
     NSArray *logStores;
     if (self.emailAttachmentAdditionsDelegate != nil) {
-        NSMutableArray *const mutableLogStores = [NSMutableArray arrayWithCapacity:self.logStores.count];
+        NSMutableArray *const filteredLogStores = [NSMutableArray arrayWithCapacity:self.logStores.count];
         for (ARKLogStore *logStore in self.logStores) {
-            if ([self.emailAttachmentAdditionsDelegate bugReporter:self shouldIncludeLogStoreInBugReport:logStore]) {
-                [mutableLogStores addObject:logStore];
+            if ([self.emailAttachmentAdditionsDelegate emailBugReporter:self shouldIncludeLogStoreInBugReport:logStore]) {
+                [filteredLogStores addObject:logStore];
             }
         }
-        logStores = mutableLogStores;
+        logStores = filteredLogStores;
     } else {
         logStores = [self.logStores copy];
     }
-    
     
     NSMapTable *logStoresToLogMessagesMap = [NSMapTable new];
     NSDictionary *emailBodyAdditions = [self.emailBodyAdditionsDelegate emailBodyAdditionsForEmailBugReporter:self];

--- a/Aardvark/ARKEmailBugReporter.m
+++ b/Aardvark/ARKEmailBugReporter.m
@@ -25,6 +25,7 @@
 
 #import "AardvarkDefines.h"
 #import "ARKDefaultLogFormatter.h"
+#import "ARKEmailAttachment.h"
 #import "ARKScreenshotLogging.h"
 #import "ARKLogMessage.h"
 #import "ARKLogStore.h"
@@ -393,7 +394,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 - (void)_createBugReportWithTitle:(NSString *)title;
 {
     NSArray *logStores;
-    if ([self.emailAttachmentAdditionsDelegate respondsToSelector:@selector(bugReporter:shouldIncludeLogStoreInBugReport:)]) {
+    if (self.emailAttachmentAdditionsDelegate != nil) {
         NSMutableArray *const mutableLogStores = [NSMutableArray arrayWithCapacity:self.logStores.count];
         for (ARKLogStore *logStore in self.logStores) {
             if ([self.emailAttachmentAdditionsDelegate bugReporter:self shouldIncludeLogStoreInBugReport:logStore]) {
@@ -470,7 +471,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
                         }
                     }
                     
-                    if ([self.emailAttachmentAdditionsDelegate respondsToSelector:@selector(additionalEmailAttachmentsForEmailBugReporter:)]) {
+                    if (self.emailAttachmentAdditionsDelegate != nil) {
                         NSArray *const additionalAttachments = [self.emailAttachmentAdditionsDelegate additionalEmailAttachmentsForEmailBugReporter:self];
                         for (ARKEmailAttachment *attachment in additionalAttachments) {
                             [self.mailComposeViewController addAttachmentData:attachment.data mimeType:attachment.dataMIMEType fileName:attachment.fileName];
@@ -643,22 +644,6 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 - (BOOL)canBecomeFirstResponder;
 {
     return YES;
-}
-
-@end
-
-
-@implementation ARKEmailAttachment
-
-- (instancetype)initWithFileName:(NSString *)fileName data:(NSData *)data dataMIMEType:(NSString *)dataMIMEType;
-{
-    self = [super init];
-    
-    _fileName = fileName;
-    _data = data;
-    _dataMIMEType = dataMIMEType;
-    
-    return self;
 }
 
 @end


### PR DESCRIPTION
Addresses #55, introducing a delegate with optional methods to:
* filter which log stores are included in a bug report email
* provide additional attachments for a bug report email