### PR TITLE
Don't animate alert presentation

### DIFF
--- a/Aardvark/ARKEmailBugReporter.m
+++ b/Aardvark/ARKEmailBugReporter.m
@@ -381,7 +381,11 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
     while (viewControllerToPresentAlertController.presentedViewController != nil) {
         viewControllerToPresentAlertController = viewControllerToPresentAlertController.presentedViewController;
     }
-    [viewControllerToPresentAlertController presentViewController:alertController animated:YES completion:NULL];
+
+    /*
+     Disabling animations here to avoid potential crashes resulting from unexpected view state in UIKit
+     */
+    [viewControllerToPresentAlertController presentViewController:alertController animated:NO completion:NULL];
 
 }
 


### PR DESCRIPTION
There seems to be a bug in UIKit around animating the presentation of the
alert controller that can result in a crash. Given that this library is for
debug purposes, it seems reasonable to avoid this crash entirely and just
disable the animation here.