### PR TITLE
Fix search behavior in log table view

### DIFF
--- a/Aardvark.podspec
+++ b/Aardvark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Aardvark'
-  s.version  = '3.4.1'
+  s.version  = '3.4.2'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark is a library that makes it dead simple to create actionable bug reports.'
   s.homepage = 'https://github.com/square/Aardvark'

--- a/Aardvark/ARKLogTableViewController.m
+++ b/Aardvark/ARKLogTableViewController.m
@@ -33,6 +33,7 @@
 
 @property (nonatomic, copy) NSArray *logMessages;
 @property (nonatomic, copy) NSArray *filteredLogs;
+@property (nonatomic, copy) NSString *searchStringForFilteredLogs;
 @property (nonatomic) BOOL viewWillAppearForFirstTimeCalled;
 @property (nonatomic) BOOL hasScrolledToBottom;
 
@@ -186,11 +187,9 @@
 - (void)updateSearchResultsForSearchController:(UISearchController *)searchController;
 {
     if (searchController.isActive) {
-        BOOL isSubset = self.searchString != nil && [searchController.searchBar.text containsString:self.searchString];
-
         self.searchString = searchController.searchBar.text;
         searchController.searchBar.placeholder = (self.searchString.length > 0) ? self.searchString : NSLocalizedString(@"Search", @"The default placeholder text for the search bar");
-        [self _reloadFilteredLogs:isSubset];
+        [self _reloadFilteredLogs];
         [self.tableView reloadData];
     }
 }
@@ -404,15 +403,18 @@
 {
     [self.logStore retrieveAllLogMessagesWithCompletionHandler:^(NSArray *logMessages) {
         self.logMessages = [self _logMessagesWithMinuteSeparators:logMessages];
-        [self _reloadFilteredLogs:false];
+        [self _reloadFilteredLogs];
         
         [self.tableView reloadData];
     }];
 }
 
-- (void)_reloadFilteredLogs:(BOOL)subsetOfPreviousFilter;
+- (void)_reloadFilteredLogs;
 {
-    if (self.searchString.length > 0 && subsetOfPreviousFilter) {
+    BOOL isSubsetOfPreviousFilter = self.searchStringForFilteredLogs != nil && [self.searchString containsString:self.searchStringForFilteredLogs];
+    self.searchStringForFilteredLogs = self.searchString;
+
+    if (self.searchString.length > 0 && isSubsetOfPreviousFilter) {
         self.filteredLogs = [self.filteredLogs filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"text CONTAINS[c] %@", self.searchString]];
     } else if (self.searchString.length > 0) {
         self.filteredLogs = [self.logMessages filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"text CONTAINS[c] %@", self.searchString]];

--- a/Aardvark/ARKLogTableViewController.m
+++ b/Aardvark/ARKLogTableViewController.m
@@ -186,9 +186,11 @@
 - (void)updateSearchResultsForSearchController:(UISearchController *)searchController;
 {
     if (searchController.isActive) {
+        BOOL isSubset = self.searchString != nil && [searchController.searchBar.text containsString:self.searchString];
+
         self.searchString = searchController.searchBar.text;
         searchController.searchBar.placeholder = (self.searchString.length > 0) ? self.searchString : NSLocalizedString(@"Search", @"The default placeholder text for the search bar");
-        [self _reloadFilteredLogs];
+        [self _reloadFilteredLogs:isSubset];
         [self.tableView reloadData];
     }
 }
@@ -402,16 +404,18 @@
 {
     [self.logStore retrieveAllLogMessagesWithCompletionHandler:^(NSArray *logMessages) {
         self.logMessages = [self _logMessagesWithMinuteSeparators:logMessages];
-        [self _reloadFilteredLogs];
+        [self _reloadFilteredLogs:false];
         
         [self.tableView reloadData];
     }];
 }
 
-- (void)_reloadFilteredLogs;
+- (void)_reloadFilteredLogs:(BOOL)subsetOfPreviousFilter;
 {
-    if (self.searchString.length > 0) {
+    if (self.searchString.length > 0 && subsetOfPreviousFilter) {
         self.filteredLogs = [self.filteredLogs filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"text CONTAINS[c] %@", self.searchString]];
+    } else if (self.searchString.length > 0) {
+        self.filteredLogs = [self.logMessages filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"text CONTAINS[c] %@", self.searchString]];
     } else {
         self.filteredLogs = self.logMessages;
     }


### PR DESCRIPTION
Previously, the search behavior wasn't working correctly when the query got less specific (i.e. you hit backspace), since it was filtering the already filtered list. This keeps that optimization when the query is getting more specific, but searches all log messages when the query becomes less specific.