### PR TITLE
Prevent integrating apps from crashing if writeData: fails

### DIFF
--- a/CoreAardvark/Private Categories/NSFileHandle+ARKAdditions.m
+++ b/CoreAardvark/Private Categories/NSFileHandle+ARKAdditions.m
@@ -46,9 +46,12 @@ typedef unsigned long long ARKFileOffset;
     uint8_t dataLengthBytes[ARKBlockLengthBytes] = { };
     ARKWriteBigEndianBlockLength(dataLengthBytes, 0, dataBlockLength);
     NSData *dataLengthData = [NSData dataWithBytes:dataLengthBytes length:ARKBlockLengthBytes];
-    
-    [self writeData:dataLengthData];
-    [self writeData:dataBlock];
+
+    @try {
+        [self writeData:dataLengthData];
+        [self writeData:dataBlock];
+    } @catch (NSException *exception) {
+    }
 }
 
 - (void)ARK_appendDataBlock:(NSData *)dataBlock;


### PR DESCRIPTION
`writeData:` causes an exception in cases where the write operation fails (e.g. low storage state).

There is a newer message `writeData:error:` that will replace `writeData:` but using that would require to wrap the entire code into some ifdef for older compiler. That makes the code harder to read with not a lot of benefit so I decided to just stick with `writeData` and wrap it in try-catch