### PR TITLE
Use system text color in ARKLogTableViewController (square#77)

### DIFF
--- a/Aardvark.podspec
+++ b/Aardvark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Aardvark'
-  s.version  = '3.4.2'
+  s.version  = '3.4.3'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark is a library that makes it dead simple to create actionable bug reports.'
   s.homepage = 'https://github.com/square/Aardvark'

--- a/Aardvark/ARKLogTableViewController.m
+++ b/Aardvark/ARKLogTableViewController.m
@@ -278,7 +278,8 @@
             backgroundColor = [UIColor redColor];
             break;
         case ARKLogTypeDefault:
-            textColor = [UIColor blackColor];
+            // Set the text color to `nil`, which causes it to be reset to the default label text color.
+            textColor = nil;
             backgroundColor = [UIColor clearColor];
             break;
         case ARKLogTypeScreenshot:


### PR DESCRIPTION
Previously, this explicitly set the text color to black, which doesn't work correctly in dark mode. Now it assigns the text color to `nil`, which [causes it to be reset to the default value](https://developer.apple.com/documentation/uikit/uilabel/1620531-textcolor) (the system text color).