### PR TITLE
use framework search path in Aardvark to pull in CoreAardvark headers

### DIFF
--- a/Aardvark.podspec
+++ b/Aardvark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Aardvark'
-  s.version  = '3.4.3'
+  s.version  = '3.4.4'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark is a library that makes it dead simple to create actionable bug reports.'
   s.homepage = 'https://github.com/square/Aardvark'

--- a/Aardvark/ARKEmailBugReporter.m
+++ b/Aardvark/ARKEmailBugReporter.m
@@ -20,17 +20,18 @@
 
 @import MessageUI;
 
+#import <CoreAardvark/AardvarkDefines.h>
+#import <CoreAardvark/ARKLogMessage.h>
+#import <CoreAardvark/ARKLogStore.h>
+
 #import "ARKEmailBugReporter.h"
 #import "ARKEmailBugReporter_Testing.h"
 
-#import "AardvarkDefines.h"
 #import "ARKDefaultLogFormatter.h"
 #import "ARKEmailAttachment.h"
 #import "ARKEmailBugReportConfiguration.h"
 #import "ARKEmailBugReportConfiguration_Protected.h"
 #import "ARKScreenshotLogging.h"
-#import "ARKLogMessage.h"
-#import "ARKLogStore.h"
 
 
 NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";

--- a/Aardvark/ARKLogTableViewController_Testing.h
+++ b/Aardvark/ARKLogTableViewController_Testing.h
@@ -18,7 +18,7 @@
 //  limitations under the License.
 //
 
-#import "ARKLogMessage.h"
+#import <CoreAardvark/ARKLogMessage.h>
 
 
 @interface ARKLogTableViewController (Private)


### PR DESCRIPTION
Same as https://github.com/square/Aardvark/pull/59 from a few years ago, I think.

I was running into a few issues building Aardvark in register since there were some imports that are needed from CoreAardvark— which is a different include path than Aardvark has