### PR TITLE
Decouple view hierarchy description from screenshot

### DIFF
--- a/Sources/AardvarkMailUI/ARKEmailBugReporter.h
+++ b/Sources/AardvarkMailUI/ARKEmailBugReporter.h
@@ -103,8 +103,8 @@ typedef void (^ARKEmailBugReporterCustomPromptCompletionBlock)(ARKEmailBugReport
 /// The window level for the email composer on iOS 7 or later. Defaults to UIWindowLevelStatusBar + 3.0.
 @property (nonatomic) UIWindowLevel emailComposeWindowLevel;
 
-/// If this bug report includes a screenshot, also attach a description of the view hierarchy. Defaults to YES.
-@property (nonatomic) BOOL attachesViewHierarchyDescriptionWithScreenshot;
+/// Controls whether the bug reporter should generate and attach a description of the view hierarchy. Defaults to YES.
+@property (nonatomic) BOOL attachesViewHierarchyDescription;
 
 /// Returns formatted log messages as NSData.
 - (nonnull NSData *)formattedLogMessagesAsData:(nonnull NSArray *)logMessages;


### PR DESCRIPTION
Previously, the view hierarchy description could only be attached to an email bug report if there was also a screenshot attached. This removes that coupling and allows them to be attached independently.

Resolves #66.