### PR TITLE
Add comments to document ARKLogExportOption

### DIFF
--- a/Sources/AardvarkLoggingUI/Log Viewing/ARKLogTableViewController.m
+++ b/Sources/AardvarkLoggingUI/Log Viewing/ARKLogTableViewController.m
@@ -27,6 +27,7 @@
 #import "ARKScreenshotViewController.h"
 #import "UIActivityViewController+ARKAdditions.h"
 
+/// Private enum to specify destination of log export (Console or File).
 typedef NS_ENUM(NSUInteger, ARKLogExportOption) {
     /// Console Export Option
     ARKLogExportOptionConsole,
@@ -351,6 +352,7 @@ typedef NS_ENUM(NSUInteger, ARKLogExportOption) {
 #endif
 }
 
+///Exports logs to specified destination. Using enum allows for a single method for exporting and avoided duplication of code.
 - (void)_exportLogsWithOption:(ARKLogExportOption)option;
 {
     #if TARGET_IPHONE_SIMULATOR

--- a/Sources/AardvarkLoggingUI/Log Viewing/ARKLogTableViewController.m
+++ b/Sources/AardvarkLoggingUI/Log Viewing/ARKLogTableViewController.m
@@ -352,7 +352,7 @@ typedef NS_ENUM(NSUInteger, ARKLogExportOption) {
 #endif
 }
 
-///Exports logs to specified destination. Using enum allows for a single method for exporting and avoided duplication of code.
+/// Exports logs to specified destination. Using enum allows for a single method for exporting and avoided duplication of code.
 - (void)_exportLogsWithOption:(ARKLogExportOption)option;
 {
     #if TARGET_IPHONE_SIMULATOR


### PR DESCRIPTION
A follow up to @dfed's [request](https://github.com/square/Aardvark/pull/92#discussion_r544024976) to add comments to document the why behind ARKLogExportOption.

If you'd prefer the duplication rather than the enum, that's valid, and I could change to use duplication of logic rather than an enum.