### PR TITLE
Fix touch handling when dismissing the email compose view

### DIFF
--- a/Aardvark.podspec
+++ b/Aardvark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Aardvark'
-  s.version  = '3.4.4'
+  s.version  = '3.4.5'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark is a library that makes it dead simple to create actionable bug reports.'
   s.homepage = 'https://github.com/square/Aardvark'

--- a/Aardvark/ARKEmailBugReporter.m
+++ b/Aardvark/ARKEmailBugReporter.m
@@ -476,7 +476,6 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
     [self.mailComposeViewController beginAppearanceTransition:YES animated:YES];
     
     self.emailComposeWindow.rootViewController = self.mailComposeViewController;
-    [self.emailComposeWindow addSubview:self.mailComposeViewController.view];
     [self.emailComposeWindow makeKeyAndVisible];
     
     [self.mailComposeViewController endAppearanceTransition];

--- a/Aardvark/ARKEmailBugReporter.m
+++ b/Aardvark/ARKEmailBugReporter.m
@@ -488,6 +488,8 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
     
     [self.mailComposeViewController.view removeFromSuperview];
     self.emailComposeWindow.rootViewController = nil;
+    // Manually hide the window so that UIKit stops retaining it
+    self.emailComposeWindow.hidden = YES;
     self.emailComposeWindow = nil;
     
     [self.mailComposeViewController endAppearanceTransition];


### PR DESCRIPTION
This fixes a bug that would prevent the previous key window from properly receiving touch events after being made key and visible again.