### PR TITLE
Extract view hierarchy description attachment code into attachment generator

### DIFF
--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		3D404FAD25564CE700CE4B83 /* ARKFileHandleAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D04D48041AB9196B00A342E9 /* ARKFileHandleAdditionsTests.m */; };
 		3D404FAE25564CE700CE4B83 /* ARKURLAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EA46F7F91ACB8448007FC415 /* ARKURLAdditionsTests.m */; };
 		3D81BC4425C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D81BC4325C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift */; };
+		3D81BC4E25C5437E00E61A49 /* ViewHierarchyAttachmentGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D81BC4D25C5437E00E61A49 /* ViewHierarchyAttachmentGeneratorTests.swift */; };
 		3D850497215EF21100B3957C /* ARKExceptionLogging_Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D850496215EF20800B3957C /* ARKExceptionLogging_Testing.h */; };
 		3D850499215EF6F500B3957C /* ARKExceptionLoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D850498215EF6F500B3957C /* ARKExceptionLoggingTests.m */; };
 		3D9F0A15255BC728000E63D7 /* ARKEmailAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9F0A14255BC728000E63D7 /* ARKEmailAttachment.swift */; };
@@ -152,6 +153,7 @@
 		3D6E2D0C20868335007B8013 /* ARKEmailBugReportConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKEmailBugReportConfiguration.m; sourceTree = "<group>"; };
 		3D6E2D0D20868335007B8013 /* ARKEmailBugReportConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKEmailBugReportConfiguration.h; sourceTree = "<group>"; };
 		3D81BC4325C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHierarchyAttachmentGenerator.swift; sourceTree = "<group>"; };
+		3D81BC4D25C5437E00E61A49 /* ViewHierarchyAttachmentGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHierarchyAttachmentGeneratorTests.swift; sourceTree = "<group>"; };
 		3D850496215EF20800B3957C /* ARKExceptionLogging_Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARKExceptionLogging_Testing.h; sourceTree = "<group>"; };
 		3D850498215EF6F500B3957C /* ARKExceptionLoggingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARKExceptionLoggingTests.m; sourceTree = "<group>"; };
 		3D90DEB720AA9B19006D4924 /* ARKEmailBugReportConfiguration_Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARKEmailBugReportConfiguration_Protected.h; sourceTree = "<group>"; };
@@ -348,6 +350,7 @@
 			isa = PBXGroup;
 			children = (
 				3DA5BF5F2556640100B6D148 /* ARKBugReportAttachmentTests.swift */,
+				3D81BC4D25C5437E00E61A49 /* ViewHierarchyAttachmentGeneratorTests.swift */,
 				EAD1442F19E073FB0065A1FF /* Info.plist */,
 			);
 			name = AardvarkTests;
@@ -962,6 +965,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3DA5BF602556640100B6D148 /* ARKBugReportAttachmentTests.swift in Sources */,
+				3D81BC4E25C5437E00E61A49 /* ViewHierarchyAttachmentGeneratorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		3D404FAA2556410500CE4B83 /* UIActivityViewController+ARKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D404FA82556410500CE4B83 /* UIActivityViewController+ARKAdditions.m */; };
 		3D404FAD25564CE700CE4B83 /* ARKFileHandleAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D04D48041AB9196B00A342E9 /* ARKFileHandleAdditionsTests.m */; };
 		3D404FAE25564CE700CE4B83 /* ARKURLAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EA46F7F91ACB8448007FC415 /* ARKURLAdditionsTests.m */; };
+		3D81BC4425C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D81BC4325C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift */; };
 		3D850497215EF21100B3957C /* ARKExceptionLogging_Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D850496215EF20800B3957C /* ARKExceptionLogging_Testing.h */; };
 		3D850499215EF6F500B3957C /* ARKExceptionLoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D850498215EF6F500B3957C /* ARKExceptionLoggingTests.m */; };
 		3D9F0A15255BC728000E63D7 /* ARKEmailAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9F0A14255BC728000E63D7 /* ARKEmailAttachment.swift */; };
@@ -150,6 +151,7 @@
 		3D404FA82556410500CE4B83 /* UIActivityViewController+ARKAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIActivityViewController+ARKAdditions.m"; sourceTree = "<group>"; };
 		3D6E2D0C20868335007B8013 /* ARKEmailBugReportConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKEmailBugReportConfiguration.m; sourceTree = "<group>"; };
 		3D6E2D0D20868335007B8013 /* ARKEmailBugReportConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKEmailBugReportConfiguration.h; sourceTree = "<group>"; };
+		3D81BC4325C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHierarchyAttachmentGenerator.swift; sourceTree = "<group>"; };
 		3D850496215EF20800B3957C /* ARKExceptionLogging_Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARKExceptionLogging_Testing.h; sourceTree = "<group>"; };
 		3D850498215EF6F500B3957C /* ARKExceptionLoggingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARKExceptionLoggingTests.m; sourceTree = "<group>"; };
 		3D90DEB720AA9B19006D4924 /* ARKEmailBugReportConfiguration_Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARKEmailBugReportConfiguration_Protected.h; sourceTree = "<group>"; };
@@ -449,6 +451,7 @@
 				3DED97122006D35B007FC95C /* ARKBugReportAttachment.h */,
 				3DED97132006D35B007FC95C /* ARKBugReportAttachment.m */,
 				3D9F0A14255BC728000E63D7 /* ARKEmailAttachment.swift */,
+				3D81BC4325C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift */,
 			);
 			path = "Bug Reporting";
 			sourceTree = "<group>";
@@ -932,6 +935,7 @@
 				EA98B9531D4BF43400B3A390 /* ARKScreenshotLogging.m in Sources */,
 				3DED97152006D35B007FC95C /* ARKBugReportAttachment.m in Sources */,
 				3D9F0A15255BC728000E63D7 /* ARKEmailAttachment.swift in Sources */,
+				3D81BC4425C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift in Sources */,
 				EA98B9121D4BEB3D00B3A390 /* ARKLogDistributor+UIAdditions.m in Sources */,
 				3DA5BF5D2556626800B6D148 /* UIApplication+ARKAdditions.swift in Sources */,
 				EA98B9621D4BFA1700B3A390 /* Aardvark.swift in Sources */,

--- a/Sources/Aardvark/Bug Reporting/ViewHierarchyAttachmentGenerator.swift
+++ b/Sources/Aardvark/Bug Reporting/ViewHierarchyAttachmentGenerator.swift
@@ -44,7 +44,7 @@ public final class ViewHierarchyAttachmentGenerator: NSObject {
         }
 
         let fileBaseName = NSLocalizedString("view_hierarchy", comment: "File name for view hierarchy attachment")
-        let fileName = (fileBaseName as NSString).appendingPathExtension("txt") ?? fileBaseName
+        let fileName = URL(fileURLWithPath: fileBaseName).appendingPathExtension("txt").lastPathComponent
 
         return ARKBugReportAttachment(
             fileName: fileName,

--- a/Sources/Aardvark/Bug Reporting/ViewHierarchyAttachmentGenerator.swift
+++ b/Sources/Aardvark/Bug Reporting/ViewHierarchyAttachmentGenerator.swift
@@ -1,0 +1,122 @@
+//
+//  Copyright 2021 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+@objc(ARKViewHierarchyAttachmentGenerator)
+public final class ViewHierarchyAttachmentGenerator: NSObject {
+
+    /// Captures a textual representation of the current view hierarchy and returns a bug report attachment containing
+    /// plain text data for that representation.
+    @objc
+    public static func captureCurrentHierarchy() -> ARKBugReportAttachment {
+        var hierarchyDescription = ""
+        for window in UIApplication.shared.windows {
+            var viewControllerMap: [UIView: UIViewController] = [:]
+            window.rootViewController?.appendRecursiveViewControllerMapping(to: &viewControllerMap)
+
+            window.appendRecursiveViewHierarchyDescription(
+                to: &hierarchyDescription,
+                indentationLevel: 0,
+                viewControllerMap: viewControllerMap
+            )
+        }
+
+        let fileBaseName = NSLocalizedString("view_hierarchy", comment: "File name for view hierarchy attachment")
+        let fileName = (fileBaseName as NSString).appendingPathExtension("txt") ?? fileBaseName
+
+        return ARKBugReportAttachment(
+            fileName: fileName,
+            data: hierarchyDescription.data(using: .utf8)!,
+            dataMIMEType: "text/plain"
+        )
+    }
+
+}
+
+// MARK: -
+
+extension UIViewController {
+
+    fileprivate func appendRecursiveViewControllerMapping(to map: inout [UIView: UIViewController]) {
+        if isViewLoaded {
+            map[view] = self
+        }
+
+        for child in children {
+            child.appendRecursiveViewControllerMapping(to: &map)
+        }
+    }
+
+}
+
+// MARK: -
+
+extension UIView {
+
+    fileprivate func appendRecursiveViewHierarchyDescription(
+        to description: inout String,
+        indentationLevel: Int,
+        viewControllerMap: [UIView: UIViewController]
+    ) {
+        if let viewController = viewControllerMap[self] {
+            description.append(String(repeating: "   | ", count: indentationLevel))
+            description.append("VC: \(viewController)\n")
+        }
+
+        description.append(String(repeating: "   | ", count: indentationLevel))
+        description.append("\(self)\n")
+
+        for subview in subviews {
+            subview.appendRecursiveViewHierarchyDescription(
+                to: &description,
+                indentationLevel: indentationLevel + 1,
+                viewControllerMap: viewControllerMap
+            )
+        }
+
+        // Each subview's layer is also a sublayer, but we should only include it in the hierarchy once (with the
+        // subview).
+        let sublayersToSkip = Set(subviews.map { $0.layer })
+
+        for sublayer in (layer.sublayers ?? []) {
+            if sublayersToSkip.contains(sublayer) {
+                continue
+            }
+
+            sublayer.appendRecursiveLayerHierarchyDescription(to: &description, indentationLevel: indentationLevel + 1)
+        }
+    }
+
+}
+
+// MARK: -
+
+extension CALayer {
+
+    fileprivate func appendRecursiveLayerHierarchyDescription(
+        to description: inout String,
+        indentationLevel: Int
+    ) {
+        description.append(String(repeating: "   | ", count: indentationLevel))
+        description.append("\(self)\n")
+
+        for sublayer in (sublayers ?? []) {
+            sublayer.appendRecursiveLayerHierarchyDescription(to: &description, indentationLevel: indentationLevel + 1)
+        }
+    }
+
+}

--- a/Sources/Aardvark/Bug Reporting/ViewHierarchyAttachmentGenerator.swift
+++ b/Sources/Aardvark/Bug Reporting/ViewHierarchyAttachmentGenerator.swift
@@ -19,12 +19,20 @@ import Foundation
 @objc(ARKViewHierarchyAttachmentGenerator)
 public final class ViewHierarchyAttachmentGenerator: NSObject {
 
+    // MARK: - Public Static Methods
+
     /// Captures a textual representation of the current view hierarchy and returns a bug report attachment containing
     /// plain text data for that representation.
     @objc
     public static func captureCurrentHierarchy() -> ARKBugReportAttachment {
+        return generateAttachment(for: UIApplication.shared.windows)
+    }
+
+    // MARK: - Internal Static Methods
+
+    internal static func generateAttachment(for windows: [UIWindow]) -> ARKBugReportAttachment {
         var hierarchyDescription = ""
-        for window in UIApplication.shared.windows {
+        for window in windows {
             var viewControllerMap: [UIView: UIViewController] = [:]
             window.rootViewController?.appendRecursiveViewControllerMapping(to: &viewControllerMap)
 

--- a/Sources/Aardvark/Bug Reporting/ViewHierarchyAttachmentGenerator.swift
+++ b/Sources/Aardvark/Bug Reporting/ViewHierarchyAttachmentGenerator.swift
@@ -25,7 +25,7 @@ public final class ViewHierarchyAttachmentGenerator: NSObject {
     /// plain text data for that representation.
     @objc
     public static func captureCurrentHierarchy() -> ARKBugReportAttachment {
-        return generateAttachment(for: UIApplication.shared.windows)
+        generateAttachment(for: UIApplication.shared.windows)
     }
 
     // MARK: - Internal Static Methods

--- a/Sources/AardvarkMailUI/ARKEmailBugReporter.m
+++ b/Sources/AardvarkMailUI/ARKEmailBugReporter.m
@@ -29,6 +29,8 @@
 #import "ARKEmailBugReportConfiguration_Protected.h"
 #import "ARKScreenshotLogging.h"
 
+#import <Aardvark/Aardvark-Swift.h>
+
 
 NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 
@@ -36,100 +38,6 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 @interface ARKInvisibleView : UIView
 @end
 
-
-@interface CALayer (HierarchyDescription)
-
-- (void)_ARK_appendRecursiveLayerHierarchyDescriptionToString:(NSMutableString *)mutableDescription withIndentationLevel:(NSUInteger)indentationLevel;
-
-@end
-
-
-@implementation CALayer (HierarchyDescription)
-
-- (void)_ARK_appendRecursiveLayerHierarchyDescriptionToString:(NSMutableString *)mutableDescription withIndentationLevel:(NSUInteger)indentationLevel;
-{
-    for (int i = 0 ; i < indentationLevel ; i++) {
-        [mutableDescription appendString:@"   | "];
-    }
-    
-    [mutableDescription appendFormat:@"%@\n", self];
-    
-    for (CALayer *sublayer in self.sublayers) {
-        [sublayer _ARK_appendRecursiveLayerHierarchyDescriptionToString:mutableDescription withIndentationLevel:(indentationLevel + 1)];
-    }
-}
-
-@end
-
-
-@interface UIView (HierarchyDescription)
-
-/// Appends the recursive description of the view hierarchy starting with the current view to the provided mutable string. Description is similar to the private `-[UIView recursiveDescription]` method.
-- (void)_ARK_appendRecursiveViewHierarchyDescriptionToString:(NSMutableString *)mutableDescription withIndentationLevel:(NSUInteger)indentationLevel usingViewControllerMap:(NSMapTable<UIView *, UIViewController *> *)viewControllerMap;
-
-@end
-
-
-@implementation UIView (HierarchyDescription)
-
-- (void)_ARK_appendRecursiveViewHierarchyDescriptionToString:(NSMutableString *)mutableDescription withIndentationLevel:(NSUInteger)indentationLevel usingViewControllerMap:(NSMapTable<UIView *, UIViewController *> *)viewControllerMap;
-{
-    UIViewController *const viewController = [viewControllerMap objectForKey:self];
-    if (viewController != nil) {
-        for (int i = 0 ; i < indentationLevel ; i++) {
-            [mutableDescription appendString:@"   | "];
-        }
-        
-        [mutableDescription appendFormat:@"VC: %@\n", viewController];
-    }
-    
-    for (int i = 0 ; i < indentationLevel ; i++) {
-        [mutableDescription appendString:@"   | "];
-    }
-    
-    [mutableDescription appendFormat:@"%@\n", self];
-    
-    // Each subview's layer is also a sublayer, but we should only include it in the hierarchy once (with the subview).
-    NSMutableSet<CALayer *> *const sublayersToSkip = [NSMutableSet<CALayer *> setWithCapacity:self.subviews.count];
-    
-    for (UIView *subview in self.subviews) {
-        [subview _ARK_appendRecursiveViewHierarchyDescriptionToString:mutableDescription withIndentationLevel:(indentationLevel + 1) usingViewControllerMap:viewControllerMap];
-        [sublayersToSkip addObject:subview.layer];
-    }
-    
-    for (CALayer *sublayer in self.layer.sublayers) {
-        if ([sublayersToSkip containsObject:sublayer]) {
-            continue;
-        }
-        
-        [sublayer _ARK_appendRecursiveLayerHierarchyDescriptionToString:mutableDescription withIndentationLevel:(indentationLevel + 1)];
-    }
-}
-
-@end
-
-
-@interface UIViewController (HierarchyDescription)
-
-- (void)_ARK_appendRecursiveViewControllerMappingToMapTable:(NSMapTable<UIView *, UIViewController *> *)mapTable;
-
-@end
-
-
-@implementation UIViewController (HierarchyDescription)
-
-- (void)_ARK_appendRecursiveViewControllerMappingToMapTable:(NSMapTable<UIView *, UIViewController *> *)mapTable;
-{
-    if (self.isViewLoaded) {
-        [mapTable setObject:self forKey:self.view];
-    }
-    
-    for (UIViewController *childViewController in self.childViewControllers) {
-        [childViewController _ARK_appendRecursiveViewControllerMappingToMapTable:mapTable];
-    }
-}
-
-@end
 
 
 @interface ARKDefaultPromptPresenter : NSObject <ARKEmailBugReporterPromptingDelegate>
@@ -149,7 +57,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 
 @property (nonatomic) BOOL attachScreenshotToNextBugReport;
 
-@property (nonatomic) NSString *viewHierarchyDescription;
+@property (nonatomic) ARKBugReportAttachment *viewHierarchyAttachment;
 
 @end
 
@@ -203,14 +111,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
     self.attachScreenshotToNextBugReport = attachScreenshot;
 
     if (self.attachesViewHierarchyDescription) {
-        NSMutableString *mutableViewHierarchyDescription = [NSMutableString new];
-        for (UIWindow *window in [UIApplication sharedApplication].windows) {
-            NSMapTable<UIView *, UIViewController *> *const viewControllerMap = [NSMapTable<UIView *, UIViewController *> strongToStrongObjectsMapTable];
-            [window.rootViewController _ARK_appendRecursiveViewControllerMappingToMapTable:viewControllerMap];
-
-            [window _ARK_appendRecursiveViewHierarchyDescriptionToString:mutableViewHierarchyDescription withIndentationLevel:0 usingViewControllerMap:viewControllerMap];
-        }
-        self.viewHierarchyDescription = mutableViewHierarchyDescription;
+        self.viewHierarchyAttachment = [ARKViewHierarchyAttachmentGenerator captureCurrentHierarchy];
     }
 
     if (attachScreenshot && !self.screenFlashView) {
@@ -428,14 +329,12 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
                 }
             }
 
-            if (configuration.includesViewHierarchyDescription && self.viewHierarchyDescription != nil) {
-                NSString *const viewHierarchyFileName = [NSLocalizedString(@"view_hierarchy", @"File name for view hierarchy attachment") stringByAppendingPathExtension:@"txt"];
-                NSData *const viewHierarchyData = [self.viewHierarchyDescription dataUsingEncoding:NSUTF8StringEncoding];
-                if (viewHierarchyData.length > 0) {
-                    [self.mailComposeViewController addAttachmentData:viewHierarchyData mimeType:@"text/plain" fileName:viewHierarchyFileName];
-                }
+            if (configuration.includesViewHierarchyDescription && self.viewHierarchyAttachment != nil) {
+                [self.mailComposeViewController addAttachmentData:self.viewHierarchyAttachment.data
+                                                         mimeType:self.viewHierarchyAttachment.dataMIMEType
+                                                         fileName:self.viewHierarchyAttachment.fileName];
             }
-            self.viewHierarchyDescription = nil;
+            self.viewHierarchyAttachment = nil;
 
             for (ARKBugReportAttachment *attachment in configuration.additionalAttachments) {
                 [self.mailComposeViewController addAttachmentData:attachment.data mimeType:attachment.dataMIMEType fileName:attachment.fileName];

--- a/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
+++ b/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
@@ -164,7 +164,7 @@ private final class TestViewController: UIViewController {
     }
 
     override var description: String {
-        return "View Controller Description"
+        "View Controller Description"
     }
 
 }

--- a/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
+++ b/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
@@ -27,7 +27,7 @@ final class ViewHierarchyAttachmentGeneratorTests: XCTestCase {
         XCTAssertEqual(attachment.dataMIMEType, "text/plain")
     }
 
-    func testDescriptionForSimpleWindow() {
+    func test_generateAttachment_description_hasExpectedFormatForSimpleWindow() {
         let window = TestWindow()
         let attachment = ViewHierarchyAttachmentGenerator.generateAttachment(for: [window])
         let description = String(data: attachment.data, encoding: .utf8)

--- a/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
+++ b/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
@@ -65,7 +65,7 @@ final class ViewHierarchyAttachmentGeneratorTests: XCTestCase {
         )
     }
 
-    func testDescriptionForWindowWithSublayers() {
+    func test_generateAttachment_description_hasExpectedFormatForWindowWithSublayers() {
         let window = TestWindow()
 
         let subview = TestView(identifier: "Subview")

--- a/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
+++ b/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
@@ -144,7 +144,7 @@ private final class TestView: UIView {
     // MARK: - UIView
 
     override var description: String {
-        return "View Description for \(identifier)"
+        "View Description for \(identifier)"
     }
 
 }

--- a/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
+++ b/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
@@ -41,7 +41,7 @@ final class ViewHierarchyAttachmentGeneratorTests: XCTestCase {
         )
     }
 
-    func testDescriptionForWindowWithSubviews() {
+    func test_generateAttachment_description_hasExpectedFormatForWindowWithSubviews() {
         let window = TestWindow()
 
         let firstSubview = TestView(identifier: "B")

--- a/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
+++ b/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
@@ -20,10 +20,15 @@ import XCTest
 
 final class ViewHierarchyAttachmentGeneratorTests: XCTestCase {
 
-    func testAttachmentMetadata() {
+    func test_generateAttachment_hasExpectedFileName() {
         let attachment = ViewHierarchyAttachmentGenerator.generateAttachment(for: [])
 
         XCTAssertEqual(attachment.fileName, "view_hierarchy.txt")
+    }
+
+    func test_generateAttachment_hasExpectedMIMEType() {
+        let attachment = ViewHierarchyAttachmentGenerator.generateAttachment(for: [])
+
         XCTAssertEqual(attachment.dataMIMEType, "text/plain")
     }
 

--- a/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
+++ b/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
@@ -117,7 +117,7 @@ final class ViewHierarchyAttachmentGeneratorTests: XCTestCase {
 private final class TestWindow: UIWindow {
 
     override var description: String {
-        return "Window Description"
+        "Window Description"
     }
 
 }

--- a/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
+++ b/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
@@ -89,7 +89,7 @@ final class ViewHierarchyAttachmentGeneratorTests: XCTestCase {
         )
     }
 
-    func testDescriptionForWindowWithViewController() {
+    func test_generateAttachment_description_hasExpectedFormatForWindowWithViewController() {
         let window = TestWindow()
 
         let viewController = TestViewController()

--- a/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
+++ b/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
@@ -1,0 +1,170 @@
+//
+//  Copyright © 2021 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+@testable import Aardvark
+
+final class ViewHierarchyAttachmentGeneratorTests: XCTestCase {
+
+    func testAttachmentMetadata() {
+        let attachment = ViewHierarchyAttachmentGenerator.generateAttachment(for: [])
+
+        XCTAssertEqual(attachment.fileName, "view_hierarchy.txt")
+        XCTAssertEqual(attachment.dataMIMEType, "text/plain")
+    }
+
+    func testDescriptionForSimpleWindow() {
+        let window = TestWindow()
+        let attachment = ViewHierarchyAttachmentGenerator.generateAttachment(for: [window])
+        let description = String(data: attachment.data, encoding: .utf8)
+
+        XCTAssertEqual(
+            description,
+            """
+            Window Description
+
+            """
+        )
+    }
+
+    func testDescriptionForWindowWithSubviews() {
+        let window = TestWindow()
+
+        let firstSubview = TestView(identifier: "B")
+        window.addSubview(firstSubview)
+        firstSubview.addSubview(TestView(identifier: "C"))
+
+        window.addSubview(TestView(identifier: "A"))
+
+        let attachment = ViewHierarchyAttachmentGenerator.generateAttachment(for: [window])
+        let description = String(data: attachment.data, encoding: .utf8)
+
+        XCTAssertEqual(
+            description,
+            """
+            Window Description
+               | View Description for B
+               |    | View Description for C
+               | View Description for A
+
+            """
+        )
+    }
+
+    func testDescriptionForWindowWithSublayers() {
+        let window = TestWindow()
+
+        let subview = TestView(identifier: "Subview")
+        window.addSubview(subview)
+
+        subview.layer.addSublayer(TestLayer())
+        subview.layer.addSublayer(TestLayer())
+
+        let attachment = ViewHierarchyAttachmentGenerator.generateAttachment(for: [window])
+        let description = String(data: attachment.data, encoding: .utf8)
+
+        XCTAssertEqual(
+            description,
+            """
+            Window Description
+               | View Description for Subview
+               |    | Layer Description
+               |    | Layer Description
+
+            """
+        )
+    }
+
+    func testDescriptionForWindowWithViewController() {
+        let window = TestWindow()
+
+        let viewController = TestViewController()
+        window.rootViewController = viewController
+        window.addSubview(viewController.view)
+
+        let attachment = ViewHierarchyAttachmentGenerator.generateAttachment(for: [window])
+        let description = String(data: attachment.data, encoding: .utf8)
+
+        XCTAssertEqual(
+            description,
+            """
+            Window Description
+               | VC: View Controller Description
+               | View Description for Managed View
+
+            """
+        )
+    }
+
+}
+
+// MARK: -
+
+private final class TestWindow: UIWindow {
+
+    override var description: String {
+        return "Window Description"
+    }
+
+}
+
+private final class TestView: UIView {
+
+    // MARK: - Life Cycle
+
+    init(identifier: String) {
+        self.identifier = identifier
+
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Private Properties
+
+    private let identifier: String
+
+    // MARK: - UIView
+
+    override var description: String {
+        return "View Description for \(identifier)"
+    }
+
+}
+
+private final class TestLayer: CALayer {
+
+    override var description: String {
+        return "Layer Description"
+    }
+
+}
+
+private final class TestViewController: UIViewController {
+
+    override func loadView() {
+        view = TestView(identifier: "Managed View")
+    }
+
+    override var description: String {
+        return "View Controller Description"
+    }
+
+}

--- a/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
+++ b/Sources/AardvarkTests/ViewHierarchyAttachmentGeneratorTests.swift
@@ -152,7 +152,7 @@ private final class TestView: UIView {
 private final class TestLayer: CALayer {
 
     override var description: String {
-        return "Layer Description"
+        "Layer Description"
     }
 
 }


### PR DESCRIPTION
This is a step towards pulling functionality out of `ARKEmailBugReporter` and into small utility classes, in order to make it easier to write a custom bug reporter.