### PR TITLE
Move generation of attachments for log store from bug reporter to generator

### DIFF
--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		3D404FAE25564CE700CE4B83 /* ARKURLAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EA46F7F91ACB8448007FC415 /* ARKURLAdditionsTests.m */; };
 		3D81BC4425C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D81BC4325C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift */; };
 		3D81BC4E25C5437E00E61A49 /* ViewHierarchyAttachmentGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D81BC4D25C5437E00E61A49 /* ViewHierarchyAttachmentGeneratorTests.swift */; };
+		3D81BC5825C54A0800E61A49 /* LogStoreAttachmentGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D81BC5725C54A0800E61A49 /* LogStoreAttachmentGenerator.swift */; };
 		3D850497215EF21100B3957C /* ARKExceptionLogging_Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D850496215EF20800B3957C /* ARKExceptionLogging_Testing.h */; };
 		3D850499215EF6F500B3957C /* ARKExceptionLoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D850498215EF6F500B3957C /* ARKExceptionLoggingTests.m */; };
 		3D9F0A15255BC728000E63D7 /* ARKEmailAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9F0A14255BC728000E63D7 /* ARKEmailAttachment.swift */; };
@@ -154,6 +155,7 @@
 		3D6E2D0D20868335007B8013 /* ARKEmailBugReportConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKEmailBugReportConfiguration.h; sourceTree = "<group>"; };
 		3D81BC4325C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHierarchyAttachmentGenerator.swift; sourceTree = "<group>"; };
 		3D81BC4D25C5437E00E61A49 /* ViewHierarchyAttachmentGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHierarchyAttachmentGeneratorTests.swift; sourceTree = "<group>"; };
+		3D81BC5725C54A0800E61A49 /* LogStoreAttachmentGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogStoreAttachmentGenerator.swift; sourceTree = "<group>"; };
 		3D850496215EF20800B3957C /* ARKExceptionLogging_Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARKExceptionLogging_Testing.h; sourceTree = "<group>"; };
 		3D850498215EF6F500B3957C /* ARKExceptionLoggingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARKExceptionLoggingTests.m; sourceTree = "<group>"; };
 		3D90DEB720AA9B19006D4924 /* ARKEmailBugReportConfiguration_Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARKEmailBugReportConfiguration_Protected.h; sourceTree = "<group>"; };
@@ -455,6 +457,7 @@
 				3DED97132006D35B007FC95C /* ARKBugReportAttachment.m */,
 				3D9F0A14255BC728000E63D7 /* ARKEmailAttachment.swift */,
 				3D81BC4325C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift */,
+				3D81BC5725C54A0800E61A49 /* LogStoreAttachmentGenerator.swift */,
 			);
 			path = "Bug Reporting";
 			sourceTree = "<group>";
@@ -936,6 +939,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EA98B9531D4BF43400B3A390 /* ARKScreenshotLogging.m in Sources */,
+				3D81BC5825C54A0800E61A49 /* LogStoreAttachmentGenerator.swift in Sources */,
 				3DED97152006D35B007FC95C /* ARKBugReportAttachment.m in Sources */,
 				3D9F0A15255BC728000E63D7 /* ARKEmailAttachment.swift in Sources */,
 				3D81BC4425C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift in Sources */,

--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		3D046DE7254D5C790045A06C /* ARKDefaultLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = EA98B9321D4BEB6E00B3A390 /* ARKDefaultLogFormatter.m */; };
 		3D046DE8254D5C7E0045A06C /* ARKDefaultLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = EA98B9311D4BEB6E00B3A390 /* ARKDefaultLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3D15E0311F9D4E13001DE13A /* ARKExceptionLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D15E02C1F9D38B1001DE13A /* ARKExceptionLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3D1B288B25D23F4800DFBB4B /* LogStoreAttachmentGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1B288A25D23F4800DFBB4B /* LogStoreAttachmentGeneratorTests.swift */; };
 		3D404FA92556410500CE4B83 /* UIActivityViewController+ARKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D404FA72556410500CE4B83 /* UIActivityViewController+ARKAdditions.h */; };
 		3D404FAA2556410500CE4B83 /* UIActivityViewController+ARKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D404FA82556410500CE4B83 /* UIActivityViewController+ARKAdditions.m */; };
 		3D404FAD25564CE700CE4B83 /* ARKFileHandleAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D04D48041AB9196B00A342E9 /* ARKFileHandleAdditionsTests.m */; };
@@ -149,6 +150,7 @@
 		3D046DC3254D5A850045A06C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3D15E02C1F9D38B1001DE13A /* ARKExceptionLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKExceptionLogging.h; sourceTree = "<group>"; };
 		3D15E02D1F9D38B1001DE13A /* ARKExceptionLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKExceptionLogging.m; sourceTree = "<group>"; };
+		3D1B288A25D23F4800DFBB4B /* LogStoreAttachmentGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogStoreAttachmentGeneratorTests.swift; sourceTree = "<group>"; };
 		3D404FA72556410500CE4B83 /* UIActivityViewController+ARKAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIActivityViewController+ARKAdditions.h"; sourceTree = "<group>"; };
 		3D404FA82556410500CE4B83 /* UIActivityViewController+ARKAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIActivityViewController+ARKAdditions.m"; sourceTree = "<group>"; };
 		3D6E2D0C20868335007B8013 /* ARKEmailBugReportConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKEmailBugReportConfiguration.m; sourceTree = "<group>"; };
@@ -352,6 +354,7 @@
 			isa = PBXGroup;
 			children = (
 				3DA5BF5F2556640100B6D148 /* ARKBugReportAttachmentTests.swift */,
+				3D1B288A25D23F4800DFBB4B /* LogStoreAttachmentGeneratorTests.swift */,
 				3D81BC4D25C5437E00E61A49 /* ViewHierarchyAttachmentGeneratorTests.swift */,
 				EAD1442F19E073FB0065A1FF /* Info.plist */,
 			);
@@ -969,6 +972,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3DA5BF602556640100B6D148 /* ARKBugReportAttachmentTests.swift in Sources */,
+				3D1B288B25D23F4800DFBB4B /* LogStoreAttachmentGeneratorTests.swift in Sources */,
 				3D81BC4E25C5437E00E61A49 /* ViewHierarchyAttachmentGeneratorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Aardvark/Bug Reporting/LogStoreAttachmentGenerator.swift
+++ b/Sources/Aardvark/Bug Reporting/LogStoreAttachmentGenerator.swift
@@ -129,7 +129,7 @@ public final class LogStoreAttachmentGenerator: NSObject {
 
     private static func screenshotFileName(for logStoreName: String?) -> String {
         var fileName = NSLocalizedString("screenshot", comment: "File name of a screenshot")
-        fileName = (fileName as NSString).appendingPathExtension("png") ?? fileName
+        fileName = URL(fileURLWithPath: fileName).appendingPathExtension("png").lastPathComponent
         if let logStoreName = logStoreName, !logStoreName.isEmpty {
             fileName = "\(logStoreName)_\(fileName)"
         }
@@ -138,7 +138,7 @@ public final class LogStoreAttachmentGenerator: NSObject {
 
     private static func logsFileName(for logStoreName: String?, fileType: String) -> String {
         var fileName = NSLocalizedString("logs", comment: "File name for logs attachments")
-        fileName = (fileName as NSString).appendingPathExtension(fileType) ?? fileName
+        fileName = URL(fileURLWithPath: fileName).appendingPathExtension(fileType).lastPathComponent
         if let logStoreName = logStoreName, !logStoreName.isEmpty {
             fileName = "\(logStoreName)_\(fileName)"
         }

--- a/Sources/Aardvark/Bug Reporting/LogStoreAttachmentGenerator.swift
+++ b/Sources/Aardvark/Bug Reporting/LogStoreAttachmentGenerator.swift
@@ -110,7 +110,7 @@ public final class LogStoreAttachmentGenerator: NSObject {
     @objc(attachmentForLogMessages:usingLogFormatter:logStoreName:)
     public static func attachment(
         for logMessages: [ARKLogMessage],
-        using logFormatter: ARKLogFormatter,
+        using logFormatter: ARKLogFormatter = ARKDefaultLogFormatter(),
         logStoreName: String?
     ) -> ARKBugReportAttachment? {
         guard !logMessages.isEmpty else {

--- a/Sources/Aardvark/Bug Reporting/LogStoreAttachmentGenerator.swift
+++ b/Sources/Aardvark/Bug Reporting/LogStoreAttachmentGenerator.swift
@@ -21,10 +21,13 @@ public final class LogStoreAttachmentGenerator: NSObject {
 
     // MARK: - Public Types
 
+    /// Container around the attachments generated from a log store.
     public struct Attachments {
 
+        // An attachment representing the textual content of the log messages in the log store.
         public var logMessagesAttachment: ARKBugReportAttachment
 
+        // An attachment containing the image from most recent screenshot log messages in the log store.
         public var latestScreenshotAttachment: ARKBugReportAttachment?
 
     }
@@ -32,6 +35,9 @@ public final class LogStoreAttachmentGenerator: NSObject {
     // MARK: - Public Static Methods
 
     /// Generates bug report attachments representing the data in the log store.
+    ///
+    /// This is a convenience for asynchronously retrieving the messages from the log store and generating the
+    /// appropriate attachments from those messages.
     ///
     /// - parameter logStore: The log store from which to read the messages.
     /// - parameter messageFormatter: The formatter used to format messages in the logs attachment.

--- a/Sources/Aardvark/Bug Reporting/LogStoreAttachmentGenerator.swift
+++ b/Sources/Aardvark/Bug Reporting/LogStoreAttachmentGenerator.swift
@@ -1,9 +1,17 @@
 //
-//  LogStoreAttachmentGenerator.swift
-//  Aardvark
+//  Copyright 2021 Square, Inc.
 //
-//  Created by Nicholas Entin on 1/30/21.
-//  Copyright © 2021 Square, Inc. All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation

--- a/Sources/Aardvark/Bug Reporting/LogStoreAttachmentGenerator.swift
+++ b/Sources/Aardvark/Bug Reporting/LogStoreAttachmentGenerator.swift
@@ -1,0 +1,118 @@
+//
+//  LogStoreAttachmentGenerator.swift
+//  Aardvark
+//
+//  Created by Nicholas Entin on 1/30/21.
+//  Copyright © 2021 Square, Inc. All rights reserved.
+//
+
+import Foundation
+
+@objc(ARKLogStoreAttachmentGenerator)
+public final class LogStoreAttachmentGenerator: NSObject {
+
+    /// Generates bug report attachments representing the data in the log store.
+    ///
+    /// - parameter includeLatestScreenshot: Whether an attachment should be generated for the last screenshot
+    /// in the log store, if one exists.
+    @objc
+    public static func attachments(
+        for logStore: ARKLogStore,
+        messageFormatter: ARKLogFormatter = ARKDefaultLogFormatter(),
+        includeLatestScreenshot: Bool,
+        completionQueue: DispatchQueue,
+        completion: @escaping ([ARKBugReportAttachment]) -> Void
+    ) {
+        logStore.retrieveAllLogMessages { logMessages in
+            let attachments = Self.attachments(
+                for: logMessages,
+                logStoreName: logStore.name,
+                messageFormatter: messageFormatter,
+                includeLatestScreenshot: includeLatestScreenshot
+            )
+
+            completionQueue.async {
+                completion(attachments)
+            }
+        }
+    }
+
+    /// Generates bug report attachments representing the log messages.
+    ///
+    /// - parameter includeLatestScreenshot: Whether an attachment should be generated for the last screenshot
+    /// in the log messages, if one exists.
+    @objc
+    public static func attachments(
+        for logMessages: [ARKLogMessage],
+        logStoreName: String?,
+        messageFormatter: ARKLogFormatter = ARKDefaultLogFormatter(),
+        includeLatestScreenshot: Bool
+    ) -> [ARKBugReportAttachment] {
+        var attachments: [ARKBugReportAttachment] = []
+
+        if includeLatestScreenshot, let attachment = attachmentForLatestScreenshot(in: logMessages, logStoreName: logStoreName) {
+            attachments.append(attachment)
+        }
+
+        let logsAttachment = attachmentForLogs(for: logMessages, using: messageFormatter, logStoreName: logStoreName)
+        attachments.append(logsAttachment)
+
+        return attachments
+    }
+
+    // MARK: - Private Methods
+
+    private static func attachmentForLatestScreenshot(
+        in logMessages: [ARKLogMessage],
+        logStoreName: String?
+    ) -> ARKBugReportAttachment? {
+        guard
+            let screenshotMessage = logMessages.reversed().first(where: { $0.type == .screenshot }),
+            let imageData = screenshotMessage.image?.pngData()
+        else {
+            return nil
+        }
+
+        return ARKBugReportAttachment(
+            fileName: screenshotFileName(for: logStoreName),
+            data: imageData,
+            dataMIMEType: "image/png"
+        )
+    }
+
+    private static func screenshotFileName(for logStoreName: String?) -> String {
+        var fileName = NSLocalizedString("screenshot", comment: "File name of a screenshot")
+        fileName = (fileName as NSString).appendingPathExtension("png") ?? fileName
+        if let logStoreName = logStoreName, !logStoreName.isEmpty {
+            fileName = "\(logStoreName)_\(fileName)"
+        }
+        return fileName
+    }
+
+    private static func attachmentForLogs(
+        for logMessages: [ARKLogMessage],
+        using logFormatter: ARKLogFormatter,
+        logStoreName: String?
+    ) -> ARKBugReportAttachment {
+        let formattedLogData = logMessages
+            .map(logFormatter.formattedLogMessage(_:))
+            .joined(separator: "\n")
+            .data(using: .utf8)!
+
+        return ARKBugReportAttachment(
+            fileName: logsFileName(for: logStoreName, fileType: "txt"),
+            data: formattedLogData,
+            dataMIMEType: "text/plain"
+        )
+    }
+
+    private static func logsFileName(for logStoreName: String?, fileType: String) -> String {
+        var fileName = NSLocalizedString("logs", comment: "File name for logs attachments")
+        fileName = (fileName as NSString).appendingPathExtension(fileType) ?? fileName
+        if let logStoreName = logStoreName, !logStoreName.isEmpty {
+            fileName = "\(logStoreName)_\(fileName)"
+        }
+        return fileName
+    }
+
+}

--- a/Sources/Aardvark/Bug Reporting/LogStoreAttachmentGenerator.swift
+++ b/Sources/Aardvark/Bug Reporting/LogStoreAttachmentGenerator.swift
@@ -25,7 +25,7 @@ public final class LogStoreAttachmentGenerator: NSObject {
     public struct Attachments {
 
         // An attachment representing the textual content of the log messages in the log store.
-        public var logMessagesAttachment: ARKBugReportAttachment
+        public var logMessagesAttachment: ARKBugReportAttachment?
 
         // An attachment containing the image from most recent screenshot log messages in the log store.
         public var latestScreenshotAttachment: ARKBugReportAttachment?
@@ -102,6 +102,8 @@ public final class LogStoreAttachmentGenerator: NSObject {
 
     /// Generates an attachment containing the log messages formatted using the specified formatter.
     ///
+    /// Returns `nil` if there are no log messages.
+    ///
     /// - parameter logMessages: The log messages to be included in the attachment.
     /// - parameter logFormatter: The formatter with which to format the log messages.
     /// - parameter logStoreName: The name of the log store from which the logs were collected.
@@ -110,7 +112,11 @@ public final class LogStoreAttachmentGenerator: NSObject {
         for logMessages: [ARKLogMessage],
         using logFormatter: ARKLogFormatter,
         logStoreName: String?
-    ) -> ARKBugReportAttachment {
+    ) -> ARKBugReportAttachment? {
+        guard !logMessages.isEmpty else {
+            return nil
+        }
+
         let formattedLogData = logMessages
             .map(logFormatter.formattedLogMessage(_:))
             .joined(separator: "\n")

--- a/Sources/AardvarkMailUI/ARKEmailBugReporter.h
+++ b/Sources/AardvarkMailUI/ARKEmailBugReporter.h
@@ -103,6 +103,6 @@ typedef void (^ARKEmailBugReporterCustomPromptCompletionBlock)(ARKEmailBugReport
 @property (nonatomic) BOOL attachesViewHierarchyDescription;
 
 /// Returns an attachment containing the log messages. Defaults to a plain text attachment containing each log message formatted using the bug reporter's `logFormatter`.
-- (nonnull ARKBugReportAttachment *)logsAttachmentForLogMessages:(nonnull NSArray<ARKLogMessage *> *)logMessages inLogStoreNamed:(nonnull NSString *)logStoreName;
+- (nonnull ARKBugReportAttachment *)attachmentForLogMessages:(nonnull NSArray<ARKLogMessage *> *)logMessages inLogStoreNamed:(nonnull NSString *)logStoreName;
 
 @end

--- a/Sources/AardvarkMailUI/ARKEmailBugReporter.h
+++ b/Sources/AardvarkMailUI/ARKEmailBugReporter.h
@@ -103,6 +103,6 @@ typedef void (^ARKEmailBugReporterCustomPromptCompletionBlock)(ARKEmailBugReport
 @property (nonatomic) BOOL attachesViewHierarchyDescription;
 
 /// Returns an attachment containing the log messages. Defaults to a plain text attachment containing each log message formatted using the bug reporter's `logFormatter`.
-- (nonnull ARKBugReportAttachment *)attachmentForLogMessages:(nonnull NSArray<ARKLogMessage *> *)logMessages inLogStoreNamed:(nonnull NSString *)logStoreName;
+- (nullable ARKBugReportAttachment *)attachmentForLogMessages:(nonnull NSArray<ARKLogMessage *> *)logMessages inLogStoreNamed:(nonnull NSString *)logStoreName;
 
 @end

--- a/Sources/AardvarkMailUI/ARKEmailBugReporter.h
+++ b/Sources/AardvarkMailUI/ARKEmailBugReporter.h
@@ -102,13 +102,4 @@ typedef void (^ARKEmailBugReporterCustomPromptCompletionBlock)(ARKEmailBugReport
 /// Controls whether the bug reporter should generate and attach a description of the view hierarchy. Defaults to YES.
 @property (nonatomic) BOOL attachesViewHierarchyDescription;
 
-/// Returns formatted log messages as NSData.
-- (nonnull NSData *)formattedLogMessagesAsData:(nonnull NSArray *)logMessages;
-
-/// Returns the MIME type of the data returned by formattedLogMessagesAsData:. MIME types are as specified by the IANA: http://www.iana.org/assignments/media-types/
-- (nonnull NSString *)formattedLogMessagesDataMIMEType;
-
-/// Returns the extension for the log attachments.
-- (nonnull NSString *)formattedLogMessagesAttachmentExtension;
-
 @end

--- a/Sources/AardvarkMailUI/ARKEmailBugReporter.h
+++ b/Sources/AardvarkMailUI/ARKEmailBugReporter.h
@@ -102,4 +102,7 @@ typedef void (^ARKEmailBugReporterCustomPromptCompletionBlock)(ARKEmailBugReport
 /// Controls whether the bug reporter should generate and attach a description of the view hierarchy. Defaults to YES.
 @property (nonatomic) BOOL attachesViewHierarchyDescription;
 
+/// Returns an attachment containing the log messages. Defaults to a plain text attachment containing each log message formatted using the bug reporter's `logFormatter`.
+- (nonnull ARKBugReportAttachment *)logsAttachmentForLogMessages:(nonnull NSArray<ARKLogMessage *> *)logMessages inLogStoreNamed:(nonnull NSString *)logStoreName;
+
 @end

--- a/Sources/AardvarkMailUI/ARKEmailBugReporter.m
+++ b/Sources/AardvarkMailUI/ARKEmailBugReporter.m
@@ -281,7 +281,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
                     ARKBugReportAttachment *const screenshotAttachment = [ARKLogStoreAttachmentGenerator attachmentForLatestScreenshotInLogMessages:logMessages
                                                                                                                                        logStoreName:[logStore name]];
 
-                    if (screenshotAttachment.data != nil) {
+                    if (screenshotAttachment != nil) {
                         [self.mailComposeViewController addAttachmentData:screenshotAttachment.data
                                                                  mimeType:screenshotAttachment.dataMIMEType
                                                                  fileName:screenshotAttachment.fileName];
@@ -290,9 +290,11 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 
                 ARKBugReportAttachment *const logsAttachment = [self attachmentForLogMessages:logMessages inLogStoreNamed:[logStore name]];
 
-                [self.mailComposeViewController addAttachmentData:logsAttachment.data
-                                                         mimeType:logsAttachment.dataMIMEType
-                                                         fileName:logsAttachment.fileName];
+                if (logsAttachment != nil) {
+                    [self.mailComposeViewController addAttachmentData:logsAttachment.data
+                                                             mimeType:logsAttachment.dataMIMEType
+                                                             fileName:logsAttachment.fileName];
+                }
 
                 NSMutableString *const emailBodyForLogStore = [NSMutableString new];
                 BOOL appendToEmailBody = NO;

--- a/Sources/AardvarkMailUI/ARKEmailBugReporter.m
+++ b/Sources/AardvarkMailUI/ARKEmailBugReporter.m
@@ -202,33 +202,6 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
     return _emailComposeWindow;
 }
 
-#pragma mark - Public Methods
-
-- (NSData *)formattedLogMessagesAsData:(NSArray *)logMessages;
-{
-    NSMutableArray *const formattedLogMessages = [NSMutableArray new];
-    for (ARKLogMessage *const logMessage in logMessages) {
-        [formattedLogMessages addObject:[self.logFormatter formattedLogMessage:logMessage]];
-    }
-    
-    NSData *const formattedLogMessagesAsData = [[formattedLogMessages componentsJoinedByString:@"\n"] dataUsingEncoding:NSUTF8StringEncoding];
-    if (formattedLogMessagesAsData != nil) {
-        return formattedLogMessagesAsData;
-    } else {
-        return [NSData new];
-    }
-}
-
-- (NSString *)formattedLogMessagesDataMIMEType;
-{
-    return @"text/plain";
-}
-
-- (NSString *)formattedLogMessagesAttachmentExtension;
-{
-    return @"txt";
-}
-
 #pragma mark - Private Methods
 
 - (void)_showBugReportPrompt;
@@ -295,15 +268,22 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
             for (ARKLogStore *logStore in logStores) {
                 NSArray *const logMessages = [logStoresToLogMessagesMap objectForKey:logStore];
 
-                NSString *screenshotFileName = [NSLocalizedString(@"screenshot", @"File name of a screenshot") stringByAppendingPathExtension:@"png"];
-                NSString *logsFileName = [NSLocalizedString(@"logs", @"File name for logs attachments") stringByAppendingPathExtension:[self formattedLogMessagesAttachmentExtension]];
+                NSArray<ARKBugReportAttachment *> *attachments = [ARKLogStoreAttachmentGenerator attachmentsFor:logMessages
+                                                                                                   logStoreName:logStore.name
+                                                                                               messageFormatter:self.logFormatter
+                                                                                        includeLatestScreenshot:(configuration.includesScreenshot && self.attachScreenshotToNextBugReport)];
+
+                for (ARKBugReportAttachment *attachment in attachments) {
+                    [self.mailComposeViewController addAttachmentData:attachment.data
+                                                             mimeType:attachment.dataMIMEType
+                                                             fileName:attachment.fileName];
+                }
+
                 NSMutableString *const emailBodyForLogStore = [NSMutableString new];
                 BOOL appendToEmailBody = NO;
 
                 if (logStore.name.length) {
                     [emailBodyForLogStore appendFormat:@"%@:\n", logStore.name];
-                    screenshotFileName = [logStore.name stringByAppendingFormat:@"_%@", screenshotFileName];
-                    logsFileName = [logStore.name stringByAppendingFormat:@"_%@", logsFileName];
                 }
 
                 NSString *const recentErrorLogs = [self _recentErrorLogMessagesAsPlainText:logMessages count:self.numberOfRecentErrorLogsToIncludeInEmailBodyWhenAttachmentsAreAvailable];
@@ -314,18 +294,6 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 
                 if (appendToEmailBody) {
                     [emailBody appendString:emailBodyForLogStore];
-                }
-
-                if (configuration.includesScreenshot && self.attachScreenshotToNextBugReport) {
-                    NSData *const mostRecentImage = [self _mostRecentImageAsPNG:logMessages];
-                    if (mostRecentImage.length > 0) {
-                        [self.mailComposeViewController addAttachmentData:mostRecentImage mimeType:@"image/png" fileName:screenshotFileName];
-                    }
-                }
-
-                NSData *const formattedLogs = [self formattedLogMessagesAsData:logMessages];
-                if (formattedLogs.length) {
-                    [self.mailComposeViewController addAttachmentData:formattedLogs mimeType:[self formattedLogMessagesDataMIMEType] fileName:logsFileName];
                 }
             }
 
@@ -429,18 +397,6 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
     } else {
         return @"";
     }
-}
-
-- (NSData *)_mostRecentImageAsPNG:(NSArray *)logMessages;
-{
-    for (ARKLogMessage *logMessage in [logMessages reverseObjectEnumerator]) {
-        UIImage *const logImage = logMessage.image;
-        if (logImage != nil) {
-            return UIImagePNGRepresentation(logImage);
-        }
-    }
-    
-    return nil;
 }
 
 - (NSURL *)_emailURLWithRecipients:(NSArray *)recipients CC:(NSString *)CCLine subject:(NSString *)subjectLine body:(NSString *)bodyText;

--- a/Sources/AardvarkMailUI/ARKEmailBugReporter.m
+++ b/Sources/AardvarkMailUI/ARKEmailBugReporter.m
@@ -173,7 +173,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 
 #pragma mark - Public Methods
 
-- (ARKBugReportAttachment *)logsAttachmentForLogMessages:(NSArray<ARKLogMessage *> *)logMessages inLogStoreNamed:(NSString *)logStoreName;
+- (ARKBugReportAttachment *)attachmentForLogMessages:(NSArray<ARKLogMessage *> *)logMessages inLogStoreNamed:(NSString *)logStoreName;
 {
     return [ARKLogStoreAttachmentGenerator attachmentForLogMessages:logMessages
                                                   usingLogFormatter:self.logFormatter
@@ -286,7 +286,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
                                                              fileName:screenshotAttachment.fileName];
                 }
 
-                ARKBugReportAttachment *const logsAttachment = [self logsAttachmentForLogMessages:logMessages inLogStoreNamed:[logStore name]];
+                ARKBugReportAttachment *const logsAttachment = [self attachmentForLogMessages:logMessages inLogStoreNamed:[logStore name]];
 
                 [self.mailComposeViewController addAttachmentData:logsAttachment.data
                                                          mimeType:logsAttachment.dataMIMEType

--- a/Sources/AardvarkMailUI/ARKEmailBugReporter.m
+++ b/Sources/AardvarkMailUI/ARKEmailBugReporter.m
@@ -281,9 +281,11 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
                     ARKBugReportAttachment *const screenshotAttachment = [ARKLogStoreAttachmentGenerator attachmentForLatestScreenshotInLogMessages:logMessages
                                                                                                                                        logStoreName:[logStore name]];
 
-                    [self.mailComposeViewController addAttachmentData:screenshotAttachment.data
-                                                             mimeType:screenshotAttachment.dataMIMEType
-                                                             fileName:screenshotAttachment.fileName];
+                    if (screenshotAttachment.data != nil) {
+                        [self.mailComposeViewController addAttachmentData:screenshotAttachment.data
+                                                                 mimeType:screenshotAttachment.dataMIMEType
+                                                                 fileName:screenshotAttachment.fileName];
+                    }
                 }
 
                 ARKBugReportAttachment *const logsAttachment = [self attachmentForLogMessages:logMessages inLogStoreNamed:[logStore name]];

--- a/Sources/AardvarkTests/LogStoreAttachmentGeneratorTests.swift
+++ b/Sources/AardvarkTests/LogStoreAttachmentGeneratorTests.swift
@@ -1,0 +1,118 @@
+//
+//  Copyright © 2021 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+@testable import Aardvark
+
+final class LogStoreAttachmentGeneratorTests: XCTestCase {
+
+    // MARK: - Tests - Log Messages Attachment
+
+    func testLogMessageAttachmentIsNilWhenEmpty() {
+        XCTAssertNil(LogStoreAttachmentGenerator.attachment(for: [], logStoreName: "test"))
+    }
+
+    func testLogMessageAttachmentContainsFormattedMessages() throws {
+        let logMessages = [
+            ARKLogMessage(text: "Message A", image: nil, type: .default, parameters: [:], userInfo: nil),
+            ARKLogMessage(text: "Message B", image: nil, type: .default, parameters: [:], userInfo: nil),
+            ARKLogMessage(text: "Message C", image: nil, type: .default, parameters: [:], userInfo: nil),
+        ]
+
+        let attachment = try XCTUnwrap(
+            LogStoreAttachmentGenerator.attachment(for: logMessages, using: TestFormatter(), logStoreName: nil)
+        )
+
+        XCTAssertEqual(
+            String(data: attachment.data, encoding: .utf8),
+            """
+            Message A
+            Message B
+            Message C
+            """
+        )
+
+        XCTAssertEqual(attachment.dataMIMEType, "text/plain")
+    }
+
+    func testLogMessageAttachmentName() throws {
+        let logMessages = [
+            ARKLogMessage(text: "Message", image: nil, type: .default, parameters: [:], userInfo: nil),
+        ]
+
+        XCTAssertEqual(
+            LogStoreAttachmentGenerator.attachment(for: logMessages, logStoreName: nil)?.fileName,
+            "logs.txt"
+        )
+        XCTAssertEqual(
+            LogStoreAttachmentGenerator.attachment(for: logMessages, logStoreName: "")?.fileName,
+            "logs.txt"
+        )
+        XCTAssertEqual(
+            LogStoreAttachmentGenerator.attachment(for: logMessages, logStoreName: "Test")?.fileName,
+            "Test_logs.txt"
+        )
+    }
+
+    // MARK: - Tests - Screenshot Attachment
+
+    func testScreenshotAttachmentName() throws {
+        let logMessages = [
+            ARKLogMessage(text: "Message", image: Factory.fakeScreenshotImage, type: .screenshot, parameters: [:], userInfo: nil),
+        ]
+
+        XCTAssertEqual(
+            LogStoreAttachmentGenerator.attachmentForLatestScreenshot(in: logMessages, logStoreName: nil)?.fileName,
+            "screenshot.png"
+        )
+        XCTAssertEqual(
+            LogStoreAttachmentGenerator.attachmentForLatestScreenshot(in: logMessages, logStoreName: "")?.fileName,
+            "screenshot.png"
+        )
+        XCTAssertEqual(
+            LogStoreAttachmentGenerator.attachmentForLatestScreenshot(in: logMessages, logStoreName: "Test")?.fileName,
+            "Test_screenshot.png"
+        )
+    }
+
+}
+
+// MARK: -
+
+private final class TestFormatter: NSObject, ARKLogFormatter {
+
+    func formattedLogMessage(_ logMessage: ARKLogMessage) -> String {
+        return logMessage.text
+    }
+
+}
+
+// MARK: -
+
+private enum Factory {
+
+    static let fakeScreenshotImage: UIImage = {
+        let view = UIView(frame: .init(x: 0, y: 0, width: 100, height: 100))
+        view.backgroundColor = .black
+
+        let renderer = UIGraphicsImageRenderer(size: view.bounds.size)
+        return renderer.image { context in
+            view.layer.render(in: context.cgContext)
+        }
+    }()
+
+}

--- a/Sources/CoreAardvark/Logging/ARKLogStore.h
+++ b/Sources/CoreAardvark/Logging/ARKLogStore.h
@@ -48,7 +48,7 @@
 @property (nullable, atomic, copy) BOOL (^logFilterBlock)(ARKLogMessage * _Nonnull logMessage);
 
 /// Retrieves an array of ARKLogMessage objects. Completion handler is called on the main queue.
-- (void)retrieveAllLogMessagesWithCompletionHandler:(nonnull void (^)(NSArray * _Nonnull logMessages))completionHandler;
+- (void)retrieveAllLogMessagesWithCompletionHandler:(nonnull void (^)(NSArray<ARKLogMessage *> * _Nonnull logMessages))completionHandler;
 
 /// Removes all logs. Completion handler is called on the main queue.
 - (void)clearLogsWithCompletionHandler:(nullable dispatch_block_t)completionHandler;

--- a/Sources/CoreAardvark/Logging/ARKLogStore.m
+++ b/Sources/CoreAardvark/Logging/ARKLogStore.m
@@ -99,7 +99,7 @@
 
 #pragma mark - Public Methods
 
-- (void)retrieveAllLogMessagesWithCompletionHandler:(nonnull void (^)(NSArray *logMessages))completionHandler;
+- (void)retrieveAllLogMessagesWithCompletionHandler:(nonnull void (^)(NSArray<ARKLogMessage *> *logMessages))completionHandler;
 {
     ARKCheckCondition(completionHandler != NULL, , @"Can not retrieve log messages without a completion handler");
     if (self.logDistributor == nil) {


### PR DESCRIPTION
This moves the generation of the log message and screenshot attachment to a generator. This will make it easier to build custom bug reporters outside of the standard email bug reporter.