### PR TITLE
Fix mail compose window creation when using scene delegate

### DIFF
--- a/Sources/AardvarkMailUI/ARKEmailBugReporter.m
+++ b/Sources/AardvarkMailUI/ARKEmailBugReporter.m
@@ -295,7 +295,7 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 {
     if (!_emailComposeWindow) {
         if (@available(iOS 13.0, *)) {
-            UIWindowScene *activeWindowScene = [self _activeWindowScene];
+            UIWindowScene *activeWindowScene = [[self class] _activeWindowScene];
             if (activeWindowScene != nil) {
                 _emailComposeWindow = [[UIWindow alloc] initWithWindowScene:activeWindowScene];
                 return _emailComposeWindow;
@@ -337,17 +337,6 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 }
 
 #pragma mark - Private Methods
-
-- (UIWindowScene *)_activeWindowScene API_AVAILABLE(ios(13.0));
-{
-    NSSet<UIScene *> *scenes = [[UIApplication sharedApplication] connectedScenes];
-    for (UIScene *scene in scenes) {
-        if ([scene isKindOfClass:[UIWindowScene class]] && scene.activationState == UISceneActivationStateForegroundActive) {
-            return (UIWindowScene *)scene;
-        }
-    }
-    return nil;
-}
 
 - (void)_showBugReportPrompt;
 {
@@ -601,6 +590,18 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
     }
 }
 
+#pragma mark - Private Static Methods
+
++ (UIWindowScene *)_activeWindowScene API_AVAILABLE(ios(13.0));
+{
+    NSSet<UIScene *> *scenes = [[UIApplication sharedApplication] connectedScenes];
+    for (UIScene *scene in scenes) {
+        if ([scene isKindOfClass:[UIWindowScene class]] && scene.activationState == UISceneActivationStateForegroundActive) {
+            return (UIWindowScene *)scene;
+        }
+    }
+    return nil;
+}
 
 @end
 

--- a/Sources/AardvarkMailUI/ARKEmailBugReporter.m
+++ b/Sources/AardvarkMailUI/ARKEmailBugReporter.m
@@ -294,6 +294,14 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 - (UIWindow *)emailComposeWindow;
 {
     if (!_emailComposeWindow) {
+        if (@available(iOS 13.0, *)) {
+            UIWindowScene *activeWindowScene = [self _activeWindowScene];
+            if (activeWindowScene != nil) {
+                _emailComposeWindow = [[UIWindow alloc] initWithWindowScene:activeWindowScene];
+                return _emailComposeWindow;
+            }
+        }
+
         _emailComposeWindow = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
         _emailComposeWindow.windowLevel = self.emailComposeWindowLevel;
     }
@@ -329,6 +337,17 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
 }
 
 #pragma mark - Private Methods
+
+- (UIWindowScene *)_activeWindowScene API_AVAILABLE(ios(13.0));
+{
+    NSSet<UIScene *> *scenes = [[UIApplication sharedApplication] connectedScenes];
+    for (UIScene *scene in scenes) {
+        if ([scene isKindOfClass:[UIWindowScene class]] && scene.activationState == UISceneActivationStateForegroundActive) {
+            return (UIWindowScene *)scene;
+        }
+    }
+    return nil;
+}
 
 - (void)_showBugReportPrompt;
 {
@@ -472,7 +491,6 @@ NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";
     [self.mailComposeViewController beginAppearanceTransition:YES animated:YES];
     
     self.emailComposeWindow.rootViewController = self.mailComposeViewController;
-    [self.emailComposeWindow addSubview:self.mailComposeViewController.view];
     [self.emailComposeWindow makeKeyAndVisible];
     
     [self.mailComposeViewController endAppearanceTransition];


### PR DESCRIPTION
In apps that use a scene delegate, windows must be initialized using the window scene, rather than being initialized with a frame.

Resolves #104.