### PR TITLE
Add convenience methods for logging to the distributor from Swift

### DIFF
--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -156,7 +156,6 @@
 		3D1B288A25D23F4800DFBB4B /* LogStoreAttachmentGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogStoreAttachmentGeneratorTests.swift; sourceTree = "<group>"; };
 		3D404FA72556410500CE4B83 /* UIActivityViewController+ARKAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIActivityViewController+ARKAdditions.h"; sourceTree = "<group>"; };
 		3D404FA82556410500CE4B83 /* UIActivityViewController+ARKAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIActivityViewController+ARKAdditions.m"; sourceTree = "<group>"; };
-		3D5483FD25DA71D3008B3C49 /* CoreAardvarkTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CoreAardvarkTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		3D5483FE25DA71D3008B3C49 /* ARKLogDistributorSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARKLogDistributorSwiftTests.swift; sourceTree = "<group>"; };
 		3D6E2D0C20868335007B8013 /* ARKEmailBugReportConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKEmailBugReportConfiguration.m; sourceTree = "<group>"; };
 		3D6E2D0D20868335007B8013 /* ARKEmailBugReportConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKEmailBugReportConfiguration.h; sourceTree = "<group>"; };
@@ -351,7 +350,6 @@
 				D04D48041AB9196B00A342E9 /* ARKFileHandleAdditionsTests.m */,
 				EA46F7F91ACB8448007FC415 /* ARKURLAdditionsTests.m */,
 				EAAB38A319E2929C00161A54 /* ARKDefaultLogFormatterTests.m */,
-				3D5483FD25DA71D3008B3C49 /* CoreAardvarkTests-Bridging-Header.h */,
 			);
 			name = CoreAardvarkTests;
 			path = Sources/CoreAardvarkTests;
@@ -1399,7 +1397,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.CoreAardvarkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_OBJC_BRIDGING_HEADER = "Sources/CoreAardvarkTests/CoreAardvarkTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
@@ -1427,7 +1425,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.CoreAardvarkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_OBJC_BRIDGING_HEADER = "Sources/CoreAardvarkTests/CoreAardvarkTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		3D046DE5254D5C700045A06C /* ARKLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = EA98B9361D4BEB6E00B3A390 /* ARKLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3D046DE7254D5C790045A06C /* ARKDefaultLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = EA98B9321D4BEB6E00B3A390 /* ARKDefaultLogFormatter.m */; };
 		3D046DE8254D5C7E0045A06C /* ARKDefaultLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = EA98B9311D4BEB6E00B3A390 /* ARKDefaultLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3D0C342025D73E10009BBDE1 /* ARKLogDistributor+SwiftAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0C341F25D73E10009BBDE1 /* ARKLogDistributor+SwiftAdditions.swift */; };
 		3D15E0311F9D4E13001DE13A /* ARKExceptionLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D15E02C1F9D38B1001DE13A /* ARKExceptionLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3D1B288B25D23F4800DFBB4B /* LogStoreAttachmentGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1B288A25D23F4800DFBB4B /* LogStoreAttachmentGeneratorTests.swift */; };
 		3D404FA92556410500CE4B83 /* UIActivityViewController+ARKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D404FA72556410500CE4B83 /* UIActivityViewController+ARKAdditions.h */; };
@@ -148,6 +149,7 @@
 		3D046DB7254D5A840045A06C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3D046DBC254D5A840045A06C /* AardvarkLoggingUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AardvarkLoggingUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D046DC3254D5A850045A06C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3D0C341F25D73E10009BBDE1 /* ARKLogDistributor+SwiftAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ARKLogDistributor+SwiftAdditions.swift"; sourceTree = "<group>"; };
 		3D15E02C1F9D38B1001DE13A /* ARKExceptionLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKExceptionLogging.h; sourceTree = "<group>"; };
 		3D15E02D1F9D38B1001DE13A /* ARKExceptionLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKExceptionLogging.m; sourceTree = "<group>"; };
 		3D1B288A25D23F4800DFBB4B /* LogStoreAttachmentGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogStoreAttachmentGeneratorTests.swift; sourceTree = "<group>"; };
@@ -536,6 +538,7 @@
 				EA98B8C91D4BE83300B3A390 /* ARKLogDistributor_Protected.h */,
 				EA98B8CA1D4BE83300B3A390 /* ARKLogDistributor_Testing.h */,
 				EA98B8CC1D4BE83300B3A390 /* ARKLogDistributor.m */,
+				3D0C341F25D73E10009BBDE1 /* ARKLogDistributor+SwiftAdditions.swift */,
 				EA98B8CD1D4BE83300B3A390 /* ARKLogMessage.h */,
 				EA98B8CE1D4BE83300B3A390 /* ARKLogMessage.m */,
 				EA98B8CF1D4BE83300B3A390 /* ARKLogObserver.h */,
@@ -984,6 +987,7 @@
 				EA98B8D81D4BE83300B3A390 /* ARKDataArchive.m in Sources */,
 				EA98B8C11D4BE82100B3A390 /* NSFileHandle+ARKAdditions.m in Sources */,
 				3D046DE7254D5C790045A06C /* ARKDefaultLogFormatter.m in Sources */,
+				3D0C342025D73E10009BBDE1 /* ARKLogDistributor+SwiftAdditions.swift in Sources */,
 				EA98B8E41D4BE83300B3A390 /* ARKLogMessage.m in Sources */,
 				EA98B8C51D4BE82100B3A390 /* NSURL+ARKAdditions.m in Sources */,
 				EA98B95A1D4BF88600B3A390 /* ARKLogging.m in Sources */,

--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		3D404FAA2556410500CE4B83 /* UIActivityViewController+ARKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D404FA82556410500CE4B83 /* UIActivityViewController+ARKAdditions.m */; };
 		3D404FAD25564CE700CE4B83 /* ARKFileHandleAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D04D48041AB9196B00A342E9 /* ARKFileHandleAdditionsTests.m */; };
 		3D404FAE25564CE700CE4B83 /* ARKURLAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EA46F7F91ACB8448007FC415 /* ARKURLAdditionsTests.m */; };
+		3D5483FF25DA71D3008B3C49 /* ARKLogDistributorSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5483FE25DA71D3008B3C49 /* ARKLogDistributorSwiftTests.swift */; };
 		3D81BC4425C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D81BC4325C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift */; };
 		3D81BC4E25C5437E00E61A49 /* ViewHierarchyAttachmentGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D81BC4D25C5437E00E61A49 /* ViewHierarchyAttachmentGeneratorTests.swift */; };
 		3D81BC5825C54A0800E61A49 /* LogStoreAttachmentGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D81BC5725C54A0800E61A49 /* LogStoreAttachmentGenerator.swift */; };
@@ -155,6 +156,8 @@
 		3D1B288A25D23F4800DFBB4B /* LogStoreAttachmentGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogStoreAttachmentGeneratorTests.swift; sourceTree = "<group>"; };
 		3D404FA72556410500CE4B83 /* UIActivityViewController+ARKAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIActivityViewController+ARKAdditions.h"; sourceTree = "<group>"; };
 		3D404FA82556410500CE4B83 /* UIActivityViewController+ARKAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIActivityViewController+ARKAdditions.m"; sourceTree = "<group>"; };
+		3D5483FD25DA71D3008B3C49 /* CoreAardvarkTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CoreAardvarkTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		3D5483FE25DA71D3008B3C49 /* ARKLogDistributorSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARKLogDistributorSwiftTests.swift; sourceTree = "<group>"; };
 		3D6E2D0C20868335007B8013 /* ARKEmailBugReportConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKEmailBugReportConfiguration.m; sourceTree = "<group>"; };
 		3D6E2D0D20868335007B8013 /* ARKEmailBugReportConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKEmailBugReportConfiguration.h; sourceTree = "<group>"; };
 		3D81BC4325C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHierarchyAttachmentGenerator.swift; sourceTree = "<group>"; };
@@ -342,11 +345,13 @@
 				EA09D3C41A2E6D2F004C1125 /* ARKDefineTests.m */,
 				D04D47EC1AB8A0BA00A342E9 /* ARKDataArchiveTests.m */,
 				EAD1445319E201C70065A1FF /* ARKLogDistributorTests.m */,
+				3D5483FE25DA71D3008B3C49 /* ARKLogDistributorSwiftTests.swift */,
 				3D850498215EF6F500B3957C /* ARKExceptionLoggingTests.m */,
 				EA73536F1A15C5E70060F54E /* ARKLogStoreTests.m */,
 				D04D48041AB9196B00A342E9 /* ARKFileHandleAdditionsTests.m */,
 				EA46F7F91ACB8448007FC415 /* ARKURLAdditionsTests.m */,
 				EAAB38A319E2929C00161A54 /* ARKDefaultLogFormatterTests.m */,
+				3D5483FD25DA71D3008B3C49 /* CoreAardvarkTests-Bridging-Header.h */,
 			);
 			name = CoreAardvarkTests;
 			path = Sources/CoreAardvarkTests;
@@ -803,6 +808,7 @@
 					EA3C1D901D934A210048C4CD = {
 						CreatedOnToolsVersion = 8.0;
 						DevelopmentTeam = EYF346PHUG;
+						LastSwiftMigration = 1230;
 						ProvisioningStyle = Automatic;
 					};
 					EA3C1D9F1D934A260048C4CD = {
@@ -961,6 +967,7 @@
 			files = (
 				3D850499215EF6F500B3957C /* ARKExceptionLoggingTests.m in Sources */,
 				EA3C1DAE1D934B1D0048C4CD /* ARKLogStoreTests.m in Sources */,
+				3D5483FF25DA71D3008B3C49 /* ARKLogDistributorSwiftTests.swift in Sources */,
 				3D404FAD25564CE700CE4B83 /* ARKFileHandleAdditionsTests.m in Sources */,
 				EA3C1DAC1D934B1D0048C4CD /* ARKDataArchiveTests.m in Sources */,
 				3DD020DF2556502E00E6400A /* ARKDefaultLogFormatterTests.m in Sources */,
@@ -1376,6 +1383,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -1391,6 +1399,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.CoreAardvarkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "Sources/CoreAardvarkTests/CoreAardvarkTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -1400,6 +1410,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -1416,6 +1427,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.CoreAardvarkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "Sources/CoreAardvarkTests/CoreAardvarkTests-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/Sources/CoreAardvark/Logging/ARKLogDistributor+SwiftAdditions.swift
+++ b/Sources/CoreAardvark/Logging/ARKLogDistributor+SwiftAdditions.swift
@@ -1,0 +1,62 @@
+//
+//  Copyright 2021 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension ARKLogDistributor {
+
+    /// Creates a log message and distributes it to the log observers.
+    ///
+    /// - parameter text: The text of the log message.
+    /// - parameter type: The type of log message.
+    /// - parameter image: An optional image to be attached to the log message. Typically used for messages of type
+    /// `.screenshot`.
+    /// - parameter parameters: A set of key/value pairs that is persisted with the log message.
+    /// - parameter userInfo: A set of key/value pairs that is _not_ persisted with the log message, but rather can be
+    /// used to control how the message is processed by various log observers.
+    public func log(
+        _ text: String,
+        type: ARKLogType = .default,
+        image: UIImage? = nil,
+        parameters: [String: String] = [:],
+        userInfo: [AnyHashable: Any]? = nil
+    ) {
+        log(withText: text, image: image, type: type, parameters: parameters, userInfo: userInfo)
+    }
+
+    /// Creates a log message and distributes it to the log observers.
+    ///
+    /// - parameter format: The format string for the text of the log message.
+    /// - parameter arguments: The arguments to apply to the format string.
+    /// - parameter type: The type of log message.
+    /// - parameter image: An optional image to be attached to the log message. Typically used for messages of type
+    /// `.screenshot`.
+    /// - parameter parameters: A set of key/value pairs that is persisted with the log message.
+    /// - parameter userInfo: A set of key/value pairs that is _not_ persisted with the log message, but rather can be
+    /// used to control how the message is processed by various log observers.
+    public func log(
+        format: String,
+        _ arguments: CVarArg...,
+        type: ARKLogType = .default,
+        image: UIImage? = nil,
+        parameters: [String: String] = [:],
+        userInfo: [AnyHashable: Any]? = nil
+    ) {
+        let text = String(format: format, arguments: arguments)
+        log(text, type: type, image: image, parameters: parameters, userInfo: userInfo)
+    }
+
+}

--- a/Sources/CoreAardvark/Logging/ARKLogDistributor+SwiftAdditions.swift
+++ b/Sources/CoreAardvark/Logging/ARKLogDistributor+SwiftAdditions.swift
@@ -18,7 +18,8 @@ import Foundation
 
 extension ARKLogDistributor {
 
-    /// Creates a log message and distributes it to the log observers.
+    /// Creates a log message and distributes it to the log observers. This is a convenience wrapper for Swift usage
+    /// around the Objective-C API.
     ///
     /// - parameter text: The text of the log message.
     /// - parameter type: The type of log message.

--- a/Sources/CoreAardvark/Logging/ARKLogDistributor+SwiftAdditions.swift
+++ b/Sources/CoreAardvark/Logging/ARKLogDistributor+SwiftAdditions.swift
@@ -37,26 +37,4 @@ extension ARKLogDistributor {
         log(withText: text, image: image, type: type, parameters: parameters, userInfo: userInfo)
     }
 
-    /// Creates a log message and distributes it to the log observers.
-    ///
-    /// - parameter format: The format string for the text of the log message.
-    /// - parameter arguments: The arguments to apply to the format string.
-    /// - parameter type: The type of log message.
-    /// - parameter image: An optional image to be attached to the log message. Typically used for messages of type
-    /// `.screenshot`.
-    /// - parameter parameters: A set of key/value pairs that is persisted with the log message.
-    /// - parameter userInfo: A set of key/value pairs that is _not_ persisted with the log message, but rather can be
-    /// used to control how the message is processed by various log observers.
-    public func log(
-        format: String,
-        _ arguments: CVarArg...,
-        type: ARKLogType = .default,
-        image: UIImage? = nil,
-        parameters: [String: String] = [:],
-        userInfo: [AnyHashable: Any]? = nil
-    ) {
-        let text = String(format: format, arguments: arguments)
-        log(text, type: type, image: image, parameters: parameters, userInfo: userInfo)
-    }
-
 }

--- a/Sources/CoreAardvarkTests/ARKLogDistributorSwiftTests.swift
+++ b/Sources/CoreAardvarkTests/ARKLogDistributorSwiftTests.swift
@@ -1,0 +1,98 @@
+//
+//  Copyright 2021 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import CoreAardvark
+import XCTest
+
+final class ARKLogDistributorSwiftTests: XCTestCase {
+
+    func test_log_defaultValues() throws {
+        let logDistributor = ARKLogDistributor()
+        let observer = TestObserver()
+        logDistributor.add(observer)
+
+        logDistributor.log("Hello world")
+
+        let distributeExpectation = expectation(description: "distributes log message")
+        logDistributor.distributeAllPendingLogs {
+            distributeExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5, handler: nil)
+
+        XCTAssertEqual(observer.observedLogMessages.count, 1)
+
+        let logMessage = try XCTUnwrap(observer.observedLogMessages.first)
+        XCTAssertEqual(logMessage.text, "Hello world")
+        XCTAssertEqual(logMessage.type, .default)
+        XCTAssertEqual(logMessage.image, nil)
+        XCTAssertEqual(logMessage.parameters, [:])
+        XCTAssert(logMessage.userInfo.isEmpty)
+    }
+
+    func test_log_explicitValues() throws {
+        let logDistributor = ARKLogDistributor()
+        let observer = TestObserver()
+        logDistributor.add(observer)
+
+        logDistributor.log(
+            "Hello world",
+            type: .error,
+            image: UIImage(),
+            parameters: ["Foo": "Bar"],
+            userInfo: ["Test": "Testing"]
+        )
+
+        let distributeExpectation = expectation(description: "distributes log message")
+        logDistributor.distributeAllPendingLogs {
+            distributeExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5, handler: nil)
+
+        XCTAssertEqual(observer.observedLogMessages.count, 1)
+
+        let logMessage = try XCTUnwrap(observer.observedLogMessages.first)
+        XCTAssertEqual(logMessage.text, "Hello world")
+        XCTAssertEqual(logMessage.type, .error)
+        XCTAssertEqual(logMessage.image, UIImage())
+        XCTAssertEqual(logMessage.parameters, ["Foo": "Bar"])
+        XCTAssertFalse(logMessage.userInfo.isEmpty)
+    }
+
+}
+
+// MARK: -
+
+extension ARKLogDistributorSwiftTests {
+
+    fileprivate final class TestObserver: NSObject, ARKLogObserver {
+
+        // MARK: - Public Properties
+
+        private(set) var observedLogMessages: [ARKLogMessage] = []
+
+        // MARK: - ARKLogObserver
+
+        var logDistributor: ARKLogDistributor?
+
+        func observe(_ logMessage: ARKLogMessage) {
+            observedLogMessages.append(logMessage)
+        }
+
+    }
+
+}

--- a/Sources/CoreAardvarkTests/ARKLogDistributorSwiftTests.swift
+++ b/Sources/CoreAardvarkTests/ARKLogDistributorSwiftTests.swift
@@ -77,22 +77,18 @@ final class ARKLogDistributorSwiftTests: XCTestCase {
 
 // MARK: -
 
-extension ARKLogDistributorSwiftTests {
+private final class TestObserver: NSObject, ARKLogObserver {
 
-    fileprivate final class TestObserver: NSObject, ARKLogObserver {
+    // MARK: - Public Properties
 
-        // MARK: - Public Properties
+    private(set) var observedLogMessages: [ARKLogMessage] = []
 
-        private(set) var observedLogMessages: [ARKLogMessage] = []
+    // MARK: - ARKLogObserver
 
-        // MARK: - ARKLogObserver
+    var logDistributor: ARKLogDistributor?
 
-        var logDistributor: ARKLogDistributor?
-
-        func observe(_ logMessage: ARKLogMessage) {
-            observedLogMessages.append(logMessage)
-        }
-
+    func observe(_ logMessage: ARKLogMessage) {
+        observedLogMessages.append(logMessage)
     }
 
 }

--- a/Sources/CoreAardvarkTests/ARKLogDistributorSwiftTests.swift
+++ b/Sources/CoreAardvarkTests/ARKLogDistributorSwiftTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 final class ARKLogDistributorSwiftTests: XCTestCase {
 
-    func test_log_defaultValues() throws {
+    func test_log_propogatesExpectedDefaultValues() throws {
         let logDistributor = ARKLogDistributor()
         let observer = TestObserver()
         logDistributor.add(observer)
@@ -43,7 +43,7 @@ final class ARKLogDistributorSwiftTests: XCTestCase {
         XCTAssert(logMessage.userInfo.isEmpty)
     }
 
-    func test_log_explicitValues() throws {
+    func test_log_propogatesPassedInValues() throws {
         let logDistributor = ARKLogDistributor()
         let observer = TestObserver()
         logDistributor.add(observer)

--- a/Sources/CoreAardvarkTests/CoreAardvarkTests-Bridging-Header.h
+++ b/Sources/CoreAardvarkTests/CoreAardvarkTests-Bridging-Header.h
@@ -1,4 +1,0 @@
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
-

--- a/Sources/CoreAardvarkTests/CoreAardvarkTests-Bridging-Header.h
+++ b/Sources/CoreAardvarkTests/CoreAardvarkTests-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+


### PR DESCRIPTION
This adds a couple of convenience methods for logging to a log distributor from Swift, to better support the use case of injecting the log distributor instead of using the global `log` function. The main advantage here over the Objective-C defined methods is the default method parameters and the better support for variadic Swift arguments.