### PR TITLE
Remove EmailAddress typealias

### DIFF
--- a/Sources/Aardvark/Aardvark.swift
+++ b/Sources/Aardvark/Aardvark.swift
@@ -17,8 +17,6 @@
 import CoreAardvark
 import Foundation
 
-public typealias EmailAddress = String
-
 @objc
 public class Aardvark : NSObject {
 

--- a/Sources/AardvarkMailUI/Aardvark+EmailBugReporting.swift
+++ b/Sources/AardvarkMailUI/Aardvark+EmailBugReporting.swift
@@ -22,7 +22,7 @@ extension Aardvark {
     /// `emailAddress`. Returns the created bug reporter for convenience.
     @objc
     public static func addDefaultBugReportingGestureWithEmailBugReporter(
-        withRecipient emailAddress: EmailAddress
+        withRecipient emailAddress: String
     ) -> ARKEmailBugReporter {
         let logStore = ARKLogDistributor.default().defaultLogStore
         let bugReporter = ARKEmailBugReporter(emailAddress: emailAddress, logStore: logStore)


### PR DESCRIPTION
This was only used in one place. I don't think it adds much in this case (since there's no real type safety with typealiases), so probably better to avoid using it.