### PR TITLE
Add file system attachment generator

### DIFF
--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		3DA743201F9D4EE500ADB183 /* ARKExceptionLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D15E02D1F9D38B1001DE13A /* ARKExceptionLogging.m */; };
 		3DD020DF2556502E00E6400A /* ARKDefaultLogFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EAAB38A319E2929C00161A54 /* ARKDefaultLogFormatterTests.m */; };
 		3DF0CB54261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF0CB53261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift */; };
+		3DFD7B5226F551C8000CE4B8 /* FileSystemAttachmentGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD7B5026F5519D000CE4B8 /* FileSystemAttachmentGeneratorTests.swift */; };
 		4551A2D91BDAD10E00F216D0 /* Aardvark.h in Headers */ = {isa = PBXBuildFile; fileRef = EAD1442419E073FB0065A1FF /* Aardvark.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4551A30A1BDAF93A00F216D0 /* ARKScreenshotLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 4551A3071BDAF93A00F216D0 /* ARKScreenshotLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA3C1D961D934A210048C4CD /* CoreAardvark.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAF2FEA01D47172400931663 /* CoreAardvark.framework */; };
@@ -177,6 +178,7 @@
 		3DA5BF572556617000B6D148 /* Aardvark+EmailBugReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Aardvark+EmailBugReporting.swift"; sourceTree = "<group>"; };
 		3DA5BF5F2556640100B6D148 /* ARKBugReportAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARKBugReportAttachmentTests.swift; sourceTree = "<group>"; };
 		3DF0CB53261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemAttachmentGenerator.swift; sourceTree = "<group>"; };
+		3DFD7B5026F5519D000CE4B8 /* FileSystemAttachmentGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemAttachmentGeneratorTests.swift; sourceTree = "<group>"; };
 		4551A2C21BDACF9000F216D0 /* Aardvark.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Aardvark.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4551A3071BDAF93A00F216D0 /* ARKScreenshotLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKScreenshotLogging.h; sourceTree = "<group>"; };
 		4551A3081BDAF93A00F216D0 /* ARKScreenshotLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKScreenshotLogging.m; sourceTree = "<group>"; };
@@ -361,6 +363,7 @@
 				3DA5BF5F2556640100B6D148 /* ARKBugReportAttachmentTests.swift */,
 				3D1B288A25D23F4800DFBB4B /* LogStoreAttachmentGeneratorTests.swift */,
 				3D81BC4D25C5437E00E61A49 /* ViewHierarchyAttachmentGeneratorTests.swift */,
+				3DFD7B5026F5519D000CE4B8 /* FileSystemAttachmentGeneratorTests.swift */,
 				EAD1442F19E073FB0065A1FF /* Info.plist */,
 			);
 			name = AardvarkTests;
@@ -982,6 +985,7 @@
 				3DA5BF602556640100B6D148 /* ARKBugReportAttachmentTests.swift in Sources */,
 				3D1B288B25D23F4800DFBB4B /* LogStoreAttachmentGeneratorTests.swift in Sources */,
 				3D81BC4E25C5437E00E61A49 /* ViewHierarchyAttachmentGeneratorTests.swift in Sources */,
+				3DFD7B5226F551C8000CE4B8 /* FileSystemAttachmentGeneratorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		3DA5BF602556640100B6D148 /* ARKBugReportAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA5BF5F2556640100B6D148 /* ARKBugReportAttachmentTests.swift */; };
 		3DA743201F9D4EE500ADB183 /* ARKExceptionLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D15E02D1F9D38B1001DE13A /* ARKExceptionLogging.m */; };
 		3DD020DF2556502E00E6400A /* ARKDefaultLogFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EAAB38A319E2929C00161A54 /* ARKDefaultLogFormatterTests.m */; };
+		3DF0CB54261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF0CB53261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift */; };
 		4551A2D91BDAD10E00F216D0 /* Aardvark.h in Headers */ = {isa = PBXBuildFile; fileRef = EAD1442419E073FB0065A1FF /* Aardvark.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4551A30A1BDAF93A00F216D0 /* ARKScreenshotLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 4551A3071BDAF93A00F216D0 /* ARKScreenshotLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA3C1D961D934A210048C4CD /* CoreAardvark.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAF2FEA01D47172400931663 /* CoreAardvark.framework */; };
@@ -175,6 +176,7 @@
 		3DA5BF462556602100B6D148 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3DA5BF572556617000B6D148 /* Aardvark+EmailBugReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Aardvark+EmailBugReporting.swift"; sourceTree = "<group>"; };
 		3DA5BF5F2556640100B6D148 /* ARKBugReportAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARKBugReportAttachmentTests.swift; sourceTree = "<group>"; };
+		3DF0CB53261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemAttachmentGenerator.swift; sourceTree = "<group>"; };
 		4551A2C21BDACF9000F216D0 /* Aardvark.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Aardvark.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4551A3071BDAF93A00F216D0 /* ARKScreenshotLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKScreenshotLogging.h; sourceTree = "<group>"; };
 		4551A3081BDAF93A00F216D0 /* ARKScreenshotLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKScreenshotLogging.m; sourceTree = "<group>"; };
@@ -463,6 +465,7 @@
 				3D9F0A14255BC728000E63D7 /* ARKEmailAttachment.swift */,
 				3D81BC4325C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift */,
 				3D81BC5725C54A0800E61A49 /* LogStoreAttachmentGenerator.swift */,
+				3DF0CB53261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift */,
 			);
 			path = BugReporting;
 			sourceTree = "<group>";
@@ -948,6 +951,7 @@
 				3D9F0A15255BC728000E63D7 /* ARKEmailAttachment.swift in Sources */,
 				3D60669126BA0F62004D9203 /* ARKBugReportAttachment.swift in Sources */,
 				3D81BC4425C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift in Sources */,
+				3DF0CB54261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift in Sources */,
 				EA98B9121D4BEB3D00B3A390 /* ARKLogDistributor+UIAdditions.m in Sources */,
 				3DA5BF5D2556626800B6D148 /* UIApplication+ARKAdditions.swift in Sources */,
 				EA98B9621D4BFA1700B3A390 /* Aardvark.swift in Sources */,

--- a/AardvarkSample/AardvarkSample/AppDelegate.swift
+++ b/AardvarkSample/AardvarkSample/AppDelegate.swift
@@ -29,8 +29,9 @@ class SampleAppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
         // This line is all you'll need to get started.
-        bugReporter = Aardvark.addDefaultBugReportingGestureWithEmailBugReporter(withRecipient: "fake-email@aardvarkbugreporting.src")
-        
+        let bugReporter = Aardvark.addDefaultBugReportingGestureWithEmailBugReporter(withRecipient: "fake-email@aardvarkbugreporting.src")
+        self.bugReporter = bugReporter
+
         // Log all log messages to Crashlytics to help debug crashes.
         ARKLogDistributor.default().add(SampleCrashlyticsLogObserver())
         
@@ -39,6 +40,9 @@ class SampleAppDelegate: UIResponder, UIApplicationDelegate {
         NSSetUncaughtExceptionHandler(existingUncaughtExceptionHandler)
         
         ARKEnableLogOnUncaughtException()
+
+        // You can optionally provide an attachment additions delegate to include custom attachments.
+        bugReporter.emailAttachmentAdditionsDelegate = self
         
         return true
     }
@@ -61,4 +65,25 @@ class SampleAppDelegate: UIResponder, UIApplicationDelegate {
 
 func existingUncaughtExceptionHandler(exception: NSException) {
     print("Existing uncaught exception handler got called for exception: \(exception)")
+}
+
+// MARK: - Attachment Additions
+
+extension SampleAppDelegate: ARKEmailBugReporterEmailAttachmentAdditionsDelegate {
+
+    func emailBugReporter(
+        _ emailBugReporter: ARKEmailBugReporter,
+        shouldIncludeLogStoreInBugReport logStore: ARKLogStore
+    ) -> Bool {
+        return true
+    }
+
+    func additionalEmailAttachments(
+        for emailBugReporter: ARKEmailBugReporter
+    ) -> [ARKBugReportAttachment]? {
+        return [
+            try? FileSystemAttachmentGenerator.attachment(),
+        ].compactMap { $0 }
+    }
+
 }

--- a/AardvarkSample/AardvarkSample/SampleViewController.swift
+++ b/AardvarkSample/AardvarkSample/SampleViewController.swift
@@ -88,6 +88,12 @@ class SampleViewController : UIViewController {
         
         // Add our log store to the bug reporter.
         bugReporter.add([tapGestureLogStore])
+
+        do {
+            try writeSampleDataToDisk()
+        } catch let error {
+            print(error)
+        }
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -172,5 +178,27 @@ class SampleViewController : UIViewController {
         }
         
         NSException(name: NSExceptionName.genericException, reason: "Debug Exception", userInfo: nil).raise()
+    }
+
+    private func writeSampleDataToDisk() throws {
+        enum Error: Swift.Error {
+            case missingApplicationSupport
+        }
+
+        let sampleData = "This is a sample text file.".data(using: .utf8)!
+
+        let fileManager = FileManager.default
+        guard
+            let applicationSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        else {
+            throw Error.missingApplicationSupport
+        }
+
+        let sampleDirectory = applicationSupport.appendingPathComponent("test_files")
+        if !fileManager.fileExists(atPath: sampleDirectory.path) {
+            try fileManager.createDirectory(at: sampleDirectory, withIntermediateDirectories: true, attributes: nil)
+        }
+
+        try sampleData.write(to: sampleDirectory.appendingPathComponent("test.txt"))
     }
 }

--- a/Sources/Aardvark/BugReporting/FileSystemAttachmentGenerator.swift
+++ b/Sources/Aardvark/BugReporting/FileSystemAttachmentGenerator.swift
@@ -72,6 +72,8 @@ public final class FileSystemAttachmentGenerator: NSObject {
         fileSizeFormatter.formattingContext = .listItem
         fileSizeFormatter.isAdaptive = true
 
+        /// The maximum padded file size character length is the longest formatted byte count string (three digit number
+        /// plus " bytes" is nine characters) plus the minimum three spaces of padding between columns.
         let maxPaddedFileSizeCharacterLength = 12
 
         let dateFormatter = ISO8601DateFormatter()

--- a/Sources/Aardvark/BugReporting/FileSystemAttachmentGenerator.swift
+++ b/Sources/Aardvark/BugReporting/FileSystemAttachmentGenerator.swift
@@ -1,0 +1,219 @@
+//
+//  Copyright 2021 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+@objc(ARKFileSystemAttachmentGenerator)
+public final class FileSystemAttachmentGenerator: NSObject {
+
+    // MARK: - Public Static Methods
+
+    /// Generates bug report attachments showing a breakdown of the file system.
+    ///
+    /// The attachment consists of:
+    /// * A list of files in each of the specified `searchPathDirectories` with their file size and content modification
+    ///   date.
+    /// * Information about the total and available capacity on the main device volume.
+    ///
+    /// - parameter searchPathDirectories: The search paths within the app's container that should be scanned for files.
+    public static func attachment(
+        searchPathDirectories: [FileManager.SearchPathDirectory] = [
+            .documentDirectory,
+            .applicationSupportDirectory,
+            .cachesDirectory,
+        ]
+    ) throws -> ARKBugReportAttachment {
+        enum Error: Swift.Error {
+            case missingDocumentDirectory
+            case missingVolumeResourceValues
+        }
+
+        let fileManager = FileManager.default
+
+        let urls = searchPathDirectories.reduce([]) {
+            $0 + fileManager.urls(for: $1, in: .userDomainMask)
+        }
+
+        var description = ""
+
+        // We need an arbitrary URL on the main device volume in order to check the capacity and determine the URL for
+        // the container. We'll use the document directory since it should always exist.
+        guard let volumeURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            throw Error.missingDocumentDirectory
+        }
+
+        let appContainerPrefixes = try self.appContainerPrefixes(for: urls.first!)
+
+        if let primaryContainerPath = appContainerPrefixes.first {
+            description += "Showing files from search paths in app container at \(primaryContainerPath)\n\n"
+        }
+
+        let propertyKeys: [URLResourceKey] = [
+            .fileSizeKey,
+            .contentModificationDateKey,
+        ]
+
+        let fileSizeFormatter = ByteCountFormatter()
+        fileSizeFormatter.zeroPadsFractionDigits = true
+        fileSizeFormatter.allowsNonnumericFormatting = false
+        fileSizeFormatter.formattingContext = .listItem
+        fileSizeFormatter.isAdaptive = true
+
+        let maxPaddedFileSizeCharacterLength = 12
+
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.timeZone = .current
+
+        for directoryURL in urls {
+            guard let enumerator = fileManager.enumerator(
+                at: directoryURL,
+                includingPropertiesForKeys: propertyKeys
+            ) else {
+                continue
+            }
+
+            let directoryDisplayPath: String
+            if let appContainerPrefix = appContainerPrefixes.first(where: { directoryURL.path.hasPrefix($0) }) {
+                directoryDisplayPath = String(directoryURL.path.dropFirst(appContainerPrefix.count))
+            } else {
+                directoryDisplayPath = directoryURL.path
+            }
+
+            description += directoryDisplayPath + "\n"
+
+            var containedFiles = false
+            for case let fileURL as URL in enumerator {
+                containedFiles = true
+
+                let resourceValues = try fileURL.resourceValues(forKeys: Set(propertyKeys))
+
+                guard let fileSize = resourceValues.fileSize else {
+                    continue
+                }
+
+                let formattedFileSize = fileSizeFormatter.string(fromByteCount: Int64(fileSize))
+
+                let formattedModifiedDate: String
+                if let modifiedDate = resourceValues.contentModificationDate {
+                    formattedModifiedDate = dateFormatter.string(from: modifiedDate)
+                } else {
+                    // This string is padded to match the length of an ISO8601 timestamp.
+                    formattedModifiedDate = "(unknown)                "
+                }
+
+                let fileDisplayPath: String
+                if let appContainerPrefix = appContainerPrefixes.first(where: { fileURL.path.hasPrefix($0) }) {
+                    fileDisplayPath = String(fileURL.path.dropFirst(appContainerPrefix.count + directoryDisplayPath.count))
+                } else {
+                    fileDisplayPath = fileURL.path
+                }
+
+                let padding = String(repeating: " ", count: maxPaddedFileSizeCharacterLength - formattedFileSize.count)
+
+                description += "\(formattedFileSize)\(padding)\(formattedModifiedDate)   \(fileDisplayPath)\n"
+            }
+
+            if !containedFiles {
+                description += "(empty directory)\n"
+            }
+
+            description += "\n"
+        }
+
+        let volumeKeys: Set<URLResourceKey> = [
+            .volumeAvailableCapacityKey,
+            .volumeAvailableCapacityForImportantUsageKey,
+            .volumeAvailableCapacityForOpportunisticUsageKey,
+            .volumeTotalCapacityKey,
+        ]
+
+        let resourceValues = try volumeURL.resourceValues(forKeys: volumeKeys)
+
+        guard
+            let availableCapacity = resourceValues.volumeAvailableCapacity,
+            let importantAvailableCapacity = resourceValues.volumeAvailableCapacityForImportantUsage,
+            let opportunisticAvailableCapacity = resourceValues.volumeAvailableCapacityForOpportunisticUsage,
+            let totalCapacity = resourceValues.volumeTotalCapacity
+        else {
+            throw Error.missingVolumeResourceValues
+        }
+
+        description += """
+
+            Available Capacity:         \(fileSizeFormatter.string(fromByteCount: Int64(availableCapacity)))
+              for Important Usage:      \(fileSizeFormatter.string(fromByteCount: Int64(importantAvailableCapacity)))
+              for Opportunistic Usage:  \(fileSizeFormatter.string(fromByteCount: Int64(opportunisticAvailableCapacity)))
+            Total Capacity:             \(fileSizeFormatter.string(fromByteCount: Int64(totalCapacity)))
+
+            """
+
+        return ARKBugReportAttachment(
+            fileName: "file_system.txt",
+            data: Data(description.utf8),
+            dataMIMEType: "text/plain"
+        )
+    }
+
+    // MARK: - Private Methods
+
+    private static func appContainerPrefixes(for directoryURL: URL) throws -> [String] {
+        let path = directoryURL.path
+
+        let uuidPattern = "[A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12}"
+
+        let deviceRegex = try NSRegularExpression(
+            pattern: "/var/mobile/Containers/Data/Application/(\(uuidPattern))"
+        )
+
+        if let match = deviceRegex.firstMatch(in: path, options: [], range: NSRange(location: 0, length: path.count)) {
+            if let applicationIDRange = Range(match.range(at: 1), in: path) {
+                let applicationID = String(path[applicationIDRange])
+
+                // In the iOS file system, `/var` is a symlink to `/private/var`. The search path directories start with
+                // `/var`, but the file enumerator returns the fully resolved path.
+                return [
+                    "/var/mobile/Containers/Data/Application/\(applicationID)",
+                    "/private/var/mobile/Containers/Data/Application/\(applicationID)",
+                ]
+            }
+        }
+
+        let simulatorRegex = try NSRegularExpression(
+            pattern: "/Users/([^/]+)/Library/Developer/CoreSimulator/Devices/(\(uuidPattern))/data/Containers/Data/Application/(\(uuidPattern))"
+        )
+
+        if let match = simulatorRegex.firstMatch(in: path, options: [], range: NSRange(location: 0, length: path.count)) {
+            guard
+                let usernameRange = Range(match.range(at: 1), in: path),
+                let deviceIDRange = Range(match.range(at: 2), in: path),
+                let applicationIDRange = Range(match.range(at: 3), in: path)
+            else {
+                return []
+            }
+
+            let username = String(path[usernameRange])
+            let deviceID = String(path[deviceIDRange])
+            let applicationID = String(path[applicationIDRange])
+
+            return [
+                "/Users/\(username)/Library/Developer/CoreSimulator/Devices/\(deviceID)/data/Containers/Data/Application/\(applicationID)",
+            ]
+        }
+
+        return []
+    }
+
+}

--- a/Sources/AardvarkTests/FileSystemAttachmentGeneratorTests.swift
+++ b/Sources/AardvarkTests/FileSystemAttachmentGeneratorTests.swift
@@ -1,0 +1,140 @@
+//
+//  Copyright © 2021 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+@testable import Aardvark
+
+final class FileSystemAttachmentGeneratorTests: XCTestCase {
+
+    func testAttachment() throws {
+        enum Error: Swift.Error {
+            case invalidTimeZone
+        }
+
+        guard let timeZone = TimeZone(secondsFromGMT: -8 * 60 * 60) else {
+            throw Error.invalidTimeZone
+        }
+
+        let containerPath = NSTemporaryDirectory()
+        let fileManager = try TestFileManager(containerPath: containerPath)
+
+        let attachment = try FileSystemAttachmentGenerator.attachment(
+            searchPathDirectories: [.applicationSupportDirectory, .documentDirectory],
+            fileManager: fileManager,
+            timeZone: timeZone
+        )
+
+        XCTAssertEqual(
+            String(data: attachment.data, encoding: .utf8),
+            """
+            Showing files from search paths in app container at \(containerPath.dropLast(1))
+
+            /application-support
+            11 bytes    1969-12-31T16:00:10-08:00   /test.txt
+
+            /documents
+            (empty directory)
+
+
+            Available Capacity:         1.00 GB
+              for Important Usage:      1.10 GB
+              for Opportunistic Usage:  900.0 MB
+            Total Capacity:             16.00 GB
+
+            """
+        )
+    }
+
+}
+
+// MARK: -
+
+final class TestFileManager: FileManaging {
+
+    // MARK: - Life Cycle
+
+    init(containerPath: String) throws {
+        let containerURL = URL(fileURLWithPath: containerPath)
+
+        applicationSupportDirectoryURL = containerURL.appendingPathComponent("application-support")
+        try realFileManager.createDirectory(at: applicationSupportDirectoryURL, withIntermediateDirectories: true)
+
+        documentDirectoryURL = containerURL.appendingPathComponent("documents")
+        try realFileManager.createDirectory(at: documentDirectoryURL, withIntermediateDirectories: true)
+
+        let fileURL = applicationSupportDirectoryURL.appendingPathComponent("test.txt")
+        try "Hello world".data(using: .utf8)?.write(to: fileURL)
+        try realFileManager.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 10)],
+            ofItemAtPath: fileURL.path
+        )
+    }
+
+    deinit {
+        try? realFileManager.removeItem(at: applicationSupportDirectoryURL)
+        try? realFileManager.removeItem(at: documentDirectoryURL)
+    }
+
+    // MARK: - Private Properties
+
+    private let realFileManager: FileManager = .default
+
+    private let applicationSupportDirectoryURL: URL
+
+    private let documentDirectoryURL: URL
+
+    // MARK: - FileManaging
+
+    func urls(
+        for directory: FileManager.SearchPathDirectory,
+        in domainMask: FileManager.SearchPathDomainMask
+    ) -> [URL] {
+        switch directory {
+        case .applicationSupportDirectory:
+            return [applicationSupportDirectoryURL]
+        case .documentDirectory:
+            return [documentDirectoryURL]
+        default:
+            XCTFail("Unexpected search path directory")
+            return []
+        }
+    }
+
+    func enumerator(
+        at url: URL,
+        includingPropertiesForKeys keys: [URLResourceKey]?,
+        options mask: FileManager.DirectoryEnumerationOptions,
+        errorHandler handler: ((URL, Error) -> Bool)?
+    ) -> FileManager.DirectoryEnumerator? {
+        return realFileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: keys,
+            options: mask,
+            errorHandler: handler
+        )
+    }
+
+    func volumeResourceValues(for url: URL) throws -> VolumeResourceValues {
+        return VolumeResourceValues(
+            availableCapacity: 1_000_000_000,
+            importantAvailableCapacity: 1_100_000_000,
+            opportunisticAvailableCapacity: 0_900_000_000,
+            totalCapacity: 16_000_000_000
+        )
+    }
+
+}


### PR DESCRIPTION
This introduces a new attachment type that shows a breakdown of the app's container in the file system. This attachment is intended to help in debugging issues related to features that store data on disk.

Here is a sample of the attachment generated using the sample app:

```
Showing files from search paths in app container at /var/mobile/Containers/Data/Application/5BB384A6-4005-4881-A34D-318128FC1BD9

/Documents
(empty directory)

/Library/Application Support
9 KB        2021-09-16T15:28:44-07:00   /SampleTapLogs.data
19.9 MB     2021-09-16T15:28:47-07:00   /ARKLogDistributor_DefaultLogStore
27 bytes    2021-09-16T15:28:44-07:00   /test_files/test.txt

/Library/Caches
(empty directory)


Available Capacity:         1.50 GB
  for Important Usage:      2.29 GB
  for Opportunistic Usage:  1.01 GB
Total Capacity:             63.94 GB
```