### PR TITLE
Add user defaults attachment generator

### DIFF
--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		3DD020DF2556502E00E6400A /* ARKDefaultLogFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EAAB38A319E2929C00161A54 /* ARKDefaultLogFormatterTests.m */; };
 		3DF0CB54261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF0CB53261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift */; };
 		3DFD7B5226F551C8000CE4B8 /* FileSystemAttachmentGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD7B5026F5519D000CE4B8 /* FileSystemAttachmentGeneratorTests.swift */; };
+		3DFD25DB26F3FD82000CE4B8 /* UserDefaultsAttachmentGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD25DA26F3FD82000CE4B8 /* UserDefaultsAttachmentGenerator.swift */; };
 		4551A2D91BDAD10E00F216D0 /* Aardvark.h in Headers */ = {isa = PBXBuildFile; fileRef = EAD1442419E073FB0065A1FF /* Aardvark.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4551A30A1BDAF93A00F216D0 /* ARKScreenshotLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 4551A3071BDAF93A00F216D0 /* ARKScreenshotLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA3C1D961D934A210048C4CD /* CoreAardvark.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAF2FEA01D47172400931663 /* CoreAardvark.framework */; };
@@ -179,6 +180,7 @@
 		3DA5BF5F2556640100B6D148 /* ARKBugReportAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARKBugReportAttachmentTests.swift; sourceTree = "<group>"; };
 		3DF0CB53261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemAttachmentGenerator.swift; sourceTree = "<group>"; };
 		3DFD7B5026F5519D000CE4B8 /* FileSystemAttachmentGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemAttachmentGeneratorTests.swift; sourceTree = "<group>"; };
+		3DFD25DA26F3FD82000CE4B8 /* UserDefaultsAttachmentGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsAttachmentGenerator.swift; sourceTree = "<group>"; };
 		4551A2C21BDACF9000F216D0 /* Aardvark.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Aardvark.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4551A3071BDAF93A00F216D0 /* ARKScreenshotLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKScreenshotLogging.h; sourceTree = "<group>"; };
 		4551A3081BDAF93A00F216D0 /* ARKScreenshotLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKScreenshotLogging.m; sourceTree = "<group>"; };
@@ -469,6 +471,7 @@
 				3D81BC4325C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift */,
 				3D81BC5725C54A0800E61A49 /* LogStoreAttachmentGenerator.swift */,
 				3DF0CB53261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift */,
+				3DFD25DA26F3FD82000CE4B8 /* UserDefaultsAttachmentGenerator.swift */,
 			);
 			path = BugReporting;
 			sourceTree = "<group>";
@@ -959,6 +962,7 @@
 				3DA5BF5D2556626800B6D148 /* UIApplication+ARKAdditions.swift in Sources */,
 				EA98B9621D4BFA1700B3A390 /* Aardvark.swift in Sources */,
 				3D6066B326BA1174004D9203 /* ARKBugReporter.swift in Sources */,
+				3DFD25DB26F3FD82000CE4B8 /* UserDefaultsAttachmentGenerator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AardvarkSample/AardvarkSample/AppDelegate.swift
+++ b/AardvarkSample/AardvarkSample/AppDelegate.swift
@@ -83,6 +83,7 @@ extension SampleAppDelegate: ARKEmailBugReporterEmailAttachmentAdditionsDelegate
     ) -> [ARKBugReportAttachment]? {
         return [
             try? FileSystemAttachmentGenerator.attachment(),
+            try? UserDefaultsAttachmentGenerator.attachment(),
         ].compactMap { $0 }
     }
 

--- a/AardvarkSample/AardvarkSample/SampleViewController.swift
+++ b/AardvarkSample/AardvarkSample/SampleViewController.swift
@@ -94,6 +94,8 @@ class SampleViewController : UIViewController {
         } catch let error {
             print(error)
         }
+
+        writeSampleDataToUserDefaults()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -201,4 +203,13 @@ class SampleViewController : UIViewController {
 
         try sampleData.write(to: sampleDirectory.appendingPathComponent("test.txt"))
     }
+
+    private func writeSampleDataToUserDefaults() {
+        let userDefaults = UserDefaults.standard
+
+        userDefaults.set(true, forKey: "com.squareup.AardvarkSample.SampleBooleanKey")
+        userDefaults.set(5, forKey: "com.squareup.AardvarkSample.SampleIntegerKey")
+        userDefaults.set("Testing", forKey: "com.squareup.AardvarkSample.SampleStringKey")
+    }
+
 }

--- a/Sources/Aardvark/BugReporting/UserDefaultsAttachmentGenerator.swift
+++ b/Sources/Aardvark/BugReporting/UserDefaultsAttachmentGenerator.swift
@@ -1,0 +1,43 @@
+//
+//  Copyright 2021 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+@objc(ARKUserDefaultsAttachmentGenerator)
+public final class UserDefaultsAttachmentGenerator: NSObject {
+
+    /// Generates an attachment containing a representation of the data in the specified user defaults store.
+    ///
+    /// - parameter userDefaults: The user defaults store from which to pull data.
+    /// - parameter fileName: An optional file name for the attachment, without the file extension.
+    public static func attachment(
+        for userDefaults: UserDefaults = .standard,
+        named fileName: String? = nil
+    ) throws -> ARKBugReportAttachment {
+        let userDefaultsDictionary = userDefaults.dictionaryRepresentation()
+
+        // Write the dictionary to disk in order to get a Plist representation.
+        let temporaryURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try (userDefaultsDictionary as NSDictionary).write(to: temporaryURL)
+
+        return ARKBugReportAttachment(
+            fileName: (fileName ?? "user_defaults") + ".plist",
+            data: try Data(contentsOf: temporaryURL),
+            dataMIMEType: "text/xml"
+        )
+    }
+
+}


### PR DESCRIPTION
This introduces a new attachment type that shows the data in the user defaults database in a Plist representation. This attachment is intended to help in debugging issues related to data store in `UserDefaults`.