### PR TITLE
Use modular imports for cross-framework dependencies

### DIFF
--- a/Sources/AardvarkLoggingUI/LogViewing/ARKLogTableViewController_Testing.h
+++ b/Sources/AardvarkLoggingUI/LogViewing/ARKLogTableViewController_Testing.h
@@ -14,7 +14,7 @@
 //  limitations under the License.
 //
 
-#import <CoreAardvark/ARKLogMessage.h>
+@import CoreAardvark;
 
 
 @interface ARKLogTableViewController (Private)

--- a/Sources/AardvarkLoggingUI/LogViewing/ARKScreenshotViewController.m
+++ b/Sources/AardvarkLoggingUI/LogViewing/ARKScreenshotViewController.m
@@ -14,7 +14,7 @@
 //  limitations under the License.
 //
 
-#import <CoreAardvark/ARKLogMessage.h>
+@import CoreAardvark;
 
 #import "ARKScreenshotViewController.h"
 

--- a/Sources/AardvarkMailUI/ARKEmailBugReporter.h
+++ b/Sources/AardvarkMailUI/ARKEmailBugReporter.h
@@ -14,10 +14,9 @@
 //  limitations under the License.
 //
 
+@import Aardvark;
 @import MessageUI;
 @import UIKit;
-
-#import <Aardvark/Aardvark-Swift.h>
 
 @class ARKBugReportAttachment;
 @class ARKEmailBugReportConfiguration;

--- a/Sources/AardvarkMailUI/ARKEmailBugReporter.m
+++ b/Sources/AardvarkMailUI/ARKEmailBugReporter.m
@@ -14,22 +14,15 @@
 //  limitations under the License.
 //
 
+@import Aardvark;
+@import CoreAardvark;
 @import MessageUI;
-
-#import <Aardvark/ARKScreenshotLogging.h>
-#import <CoreAardvark/AardvarkDefines.h>
-#import <CoreAardvark/ARKDefaultLogFormatter.h>
-#import <CoreAardvark/ARKLogMessage.h>
-#import <CoreAardvark/ARKLogStore.h>
 
 #import "ARKEmailBugReporter.h"
 #import "ARKEmailBugReporter_Testing.h"
 
 #import "ARKEmailBugReportConfiguration.h"
 #import "ARKEmailBugReportConfiguration_Protected.h"
-
-
-#import <Aardvark/Aardvark-Swift.h>
 
 
 NSString *const ARKScreenshotFlashAnimationKey = @"ScreenshotFlashAnimation";


### PR DESCRIPTION
Replaces the importing of individual header files across frameworks with modular imports. This reduces the side effects of converting some of the old Objective-C classes to Swift, since previously this could break imports in other Aardvark modules.