### PR TITLE
Catch exceptions thrown when failing to write data to disk

### DIFF
--- a/CoreAardvark.podspec
+++ b/CoreAardvark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'CoreAardvark'
-  s.version  = '3.0.1'
+  s.version  = '3.0.2'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark is a library that makes it dead simple to create actionable bug reports. Usable by extensions.'
   s.homepage = 'https://github.com/square/Aardvark'

--- a/Sources/CoreAardvark/PrivateCategories/NSFileHandle+ARKAdditions.m
+++ b/Sources/CoreAardvark/PrivateCategories/NSFileHandle+ARKAdditions.m
@@ -43,8 +43,14 @@ typedef unsigned long long ARKFileOffset;
     ARKWriteBigEndianBlockLength(dataLengthBytes, 0, dataBlockLength);
     NSData *dataLengthData = [NSData dataWithBytes:dataLengthBytes length:ARKBlockLengthBytes];
     
-    [self writeData:dataLengthData];
-    [self writeData:dataBlock];
+    @try {
+        [self writeData:dataLengthData];
+        [self writeData:dataBlock];
+    } @catch (NSException *exception) {
+        NSLog(@"ERROR: -[%@ %@] Unable to write data block (%@ bytes) to disk",
+              NSStringFromClass([self class]), NSStringFromSelector(_cmd),
+              @(dataBlockLength));
+    }
 }
 
 - (void)ARK_appendDataBlock:(NSData *)dataBlock;


### PR DESCRIPTION
I don't love logging in the console without any other recovery, but, crashing feels like an even worse thing to do 😅

Since `-[NSFileHandle ARK_writeDataBlock:]` is only used by `-[NSFileHandle ARK_appendDataBlock:]`, and `ARK_appendDataBlock:` is only used async (`-[ARKDataArchive appendArchiveOfObject:]`) there's no easy way to return and indicate a failure

I bet this'd be easier with `async` / `await` in Swift, but, rewriting everything for this bug seems like a maybe not-so-great idea!