### PR TITLE
avoid leaking objects when exceptions are thrown

### DIFF
--- a/CoreAardvark.podspec
+++ b/CoreAardvark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'CoreAardvark'
-  s.version  = '3.0.2'
+  s.version  = '3.0.3'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark is a library that makes it dead simple to create actionable bug reports. Usable by extensions.'
   s.homepage = 'https://github.com/square/Aardvark'

--- a/Sources/CoreAardvark/PrivateCategories/NSFileHandle+ARKAdditions.m
+++ b/Sources/CoreAardvark/PrivateCategories/NSFileHandle+ARKAdditions.m
@@ -42,10 +42,15 @@ typedef unsigned long long ARKFileOffset;
     uint8_t dataLengthBytes[ARKBlockLengthBytes] = { };
     ARKWriteBigEndianBlockLength(dataLengthBytes, 0, dataBlockLength);
     NSData *dataLengthData = [NSData dataWithBytes:dataLengthBytes length:ARKBlockLengthBytes];
-    
+
+    NSMutableData *combinedData = [dataLengthData mutableCopy];
+    [combinedData appendData:dataBlock];
+
+    __weak NSData *weakCombinedData = combinedData;
     @try {
-        [self writeData:dataLengthData];
-        [self writeData:dataBlock];
+        @autoreleasepool {
+            [self writeData:weakCombinedData];
+        }
     } @catch (NSException *exception) {
         NSLog(@"ERROR: -[%@ %@] Unable to write data block (%@ bytes) to disk",
               NSStringFromClass([self class]), NSStringFromSelector(_cmd),


### PR DESCRIPTION
@jbmorgan pointed out that by default, under ARC, the lifetime of a variable caught in an exception does not end when a scope ends https://clang.llvm.org/docs/AutomaticReferenceCounting.html#exceptions

by making a `__weak` reference before entering an `@try` block, we can avoid leaking memory when hitting assertions around low disk space (to avoid also crashing due to low memory!)

similarly @JaviSoto pointed out that we should combine data into one object before calling write, to ensure we atomically write everything or nothing.