### PR TITLE
Enable an async callback-based analogue to LogStoreAttachmentGenerator

### DIFF
--- a/Sources/AardvarkMailUI/ARKEmailBugReporter.h
+++ b/Sources/AardvarkMailUI/ARKEmailBugReporter.h
@@ -47,6 +47,7 @@
 
 @end
 
+typedef void (^ARKAttachmentGeneratorCompletionBlock)(ARKBugReportAttachment * _Nullable attachment);
 
 typedef void (^ARKEmailBugReporterCustomPromptCompletionBlock)(ARKEmailBugReportConfiguration *_Nullable configuration);
 
@@ -101,6 +102,9 @@ typedef void (^ARKEmailBugReporterCustomPromptCompletionBlock)(ARKEmailBugReport
 @property (nonatomic) BOOL attachesViewHierarchyDescription;
 
 /// Returns an attachment containing the log messages. Defaults to a plain text attachment containing each log message formatted using the bug reporter's `logFormatter`.
-- (nullable ARKBugReportAttachment *)attachmentForLogMessages:(nonnull NSArray<ARKLogMessage *> *)logMessages inLogStoreNamed:(nonnull NSString *)logStoreName;
+- (nullable ARKBugReportAttachment *)attachmentForLogMessages:(nonnull NSArray<ARKLogMessage *> *)logMessages inLogStoreNamed:(nonnull NSString *)logStoreName __attribute__((deprecated("Use the async version of this method that takes a completion handler: attachmentForLogMessages:inLogStoreNamed:completion: instead.")));
+
+/// Returns an attachment containing the log messages to a completion handler. Defaults to a plain text attachment containing each log message formatted using the bug reporter's `logFormatter`.
+- (void) attachmentForLogMessages:(nonnull NSArray<ARKLogMessage *> *)logMessages inLogStoreNamed:(nonnull NSString *)logStoreName completion: (ARKAttachmentGeneratorCompletionBlock _Nonnull) completionHandler;
 
 @end


### PR DESCRIPTION
### What
This PR adds a callback-ified version to `LogStoreAttachmentGenerator`'s  `attachmentForLogMessages:usingLogFormatter:logStoreName:` function.

### Why
The current synchronous API design limits subclasses of `LogStoreAttachmentGenerator` from being able to generate attachments asynchronously. For example: using `NSFileCoordinator` to compress a directory of log files, as it itself has a callback based API in which it returns results.

### How
I marked the existing method as deprecated, while providing an async version.