### PR TITLE
Bump Aardvark to 4.0.1 and AardvarkMailUI to 1.0.1 - to reflect changes in 7220a7

### DIFF
--- a/Aardvark.podspec
+++ b/Aardvark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Aardvark'
-  s.version  = '4.0.0'
+  s.version  = '4.1.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark is a library that makes it dead simple to create actionable bug reports.'
   s.homepage = 'https://github.com/square/Aardvark'

--- a/AardvarkMailUI.podspec
+++ b/AardvarkMailUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'AardvarkMailUI'
-  s.version  = '1.0.0'
+  s.version  = '1.1'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark components for submitting a bug report via an email composer.'
   s.homepage = 'https://github.com/square/Aardvark'
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/AardvarkMailUI/**/*.{h,m,swift}'
   s.private_header_files = 'Sources/AardvarkMailUI/**/*_Testing.h', 'Sources/AardvarkMailUI/PrivateCategories/*.h'
 
-  s.dependency 'Aardvark', '~> 4.0'
+  s.dependency 'Aardvark', '~> 4.1.0'
 end


### PR DESCRIPTION
Bump Aardvark to 4.0.1 and AardvarkMailUI to 1.0.1 - to reflect changes in https://github.com/square/Aardvark/pull/138