### PR TITLE
Add ability to turn off logging after encountering an ObjC exception

### DIFF
--- a/CoreAardvark.podspec
+++ b/CoreAardvark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'CoreAardvark'
-  s.version  = '3.0.2'
+  s.version  = '3.1.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark is a library that makes it dead simple to create actionable bug reports. Usable by extensions.'
   s.homepage = 'https://github.com/square/Aardvark'

--- a/Sources/CoreAardvark/Logging/ARKExceptionLogging.m
+++ b/Sources/CoreAardvark/Logging/ARKExceptionLogging.m
@@ -81,7 +81,7 @@ void ARKHandleUncaughtException(NSException *_Nonnull exception)
     }
 }
 
-void ARKEnableLogOnUncaughtException()
+void ARKEnableLogOnUncaughtException(void)
 {
     ARKEnableLogOnUncaughtExceptionToLogDistributor([ARKLogDistributor defaultDistributor]);
 }
@@ -105,7 +105,7 @@ void ARKEnableLogOnUncaughtExceptionToLogDistributor(ARKLogDistributor *_Nonnull
     [logDistributorsLock unlock];
 }
 
-void ARKDisableLogOnUncaughtException()
+void ARKDisableLogOnUncaughtException(void)
 {
     ARKDisableLogOnUncaughtExceptionToLogDistributor([ARKLogDistributor defaultDistributor]);
 }

--- a/Sources/CoreAardvark/PrivateCategories/NSFileHandle+ARKAdditions.h
+++ b/Sources/CoreAardvark/PrivateCategories/NSFileHandle+ARKAdditions.h
@@ -22,6 +22,10 @@ extern NSUInteger const ARKInvalidDataBlockLength;
 
 @interface NSFileHandle (ARKAdditions)
 
+/// Should Aardvark stop logging after catching a `NSException`?
+/// Default: `NO` to avoid changing API behavior within the same major (as in major.minor.patch versioning) version
++ (void)ARK_setPreventWritesAfterException:(BOOL)preventWritesAfterException;
+
 /// Writes the length of dataBlock, and then its contents. Note: this writes (or over-writes) at the current offsetInFile.
 - (void)ARK_writeDataBlock:(nonnull NSData *)dataBlock;
 

--- a/Sources/CoreAardvark/PrivateCategories/NSFileHandle+ARKAdditions.m
+++ b/Sources/CoreAardvark/PrivateCategories/NSFileHandle+ARKAdditions.m
@@ -18,8 +18,22 @@
 
 #import "AardvarkDefines.h"
 
+#import <stdatomic.h>
+#import <stdbool.h>
+
 
 NSUInteger const ARKInvalidDataBlockLength = NSUIntegerMax;
+
+
+// If any thread hits an exception, stop all future logging to all threads:
+// 1. @throw'n exceptions are in Objective-C are not expected to be recoverable;
+//    it is preferred to halt all action that could result in further bad behavior.
+// 2. Any exception caught by an @catch block will leak its contents, and
+//    leaking memory every time we fail to log (for example: due to being out
+//    of disk space) is almost as bad as crashing.
+static _Atomic bool __ARKHasEncounteredDiskSizeException = false;
+static _Atomic bool __ARKPreventsWritesAfterException = false;
+
 
 /// Type convenience.
 typedef unsigned long long ARKFileOffset;
@@ -32,8 +46,30 @@ typedef unsigned long long ARKFileOffset;
 
 @implementation NSFileHandle (ARKAdditions)
 
++ (void)ARK_setPreventWritesAfterException:(BOOL)preventWritesAfterException
+{
+    // convert from ObjC BOOL (a `char` on some platforms) to stdbool
+    // see: Special Considerations on https://developer.apple.com/documentation/objectivec/bool
+    bool stdboolPreventWritesAfterException = !!preventWritesAfterException;
+    atomic_store(&__ARKPreventsWritesAfterException, stdboolPreventWritesAfterException);
+
+    if (!stdboolPreventWritesAfterException) {
+        // if we are re-enabling logging, reset state that could prevent writes,
+        // in case we previously encountered an error
+        atomic_store(&__ARKHasEncounteredDiskSizeException, false);
+    }
+}
+
+#pragma mark -
+
 - (void)ARK_writeDataBlock:(NSData *)dataBlock;
 {
+    bool hasEncounteredException = atomic_load(&__ARKHasEncounteredDiskSizeException);
+    bool preventWritesAfterException = atomic_load(&__ARKPreventsWritesAfterException);
+    if (hasEncounteredException && preventWritesAfterException) {
+        return;
+    }
+
     NSUInteger dataBlockLength = dataBlock.length;
     
     ARKCheckCondition(dataBlockLength > 0, , @"Can't write data block %@", dataBlock);
@@ -47,9 +83,13 @@ typedef unsigned long long ARKFileOffset;
         [self writeData:dataLengthData];
         [self writeData:dataBlock];
     } @catch (NSException *exception) {
-        NSLog(@"ERROR: -[%@ %@] Unable to write data block (%@ bytes) to disk",
+        NSLog(@"ERROR: -[%@ %@] Unable to write data block (%@ bytes) to disk: %@",
               NSStringFromClass([self class]), NSStringFromSelector(_cmd),
-              @(dataBlockLength));
+              @(dataBlockLength), exception);
+
+        if ([exception.name isEqualToString:NSFileHandleOperationException]) {
+            atomic_store(&__ARKHasEncounteredDiskSizeException, true);
+        }
     }
 }
 

--- a/Sources/CoreAardvark/PrivateCategories/NSFileHandle+ARKAdditions.m
+++ b/Sources/CoreAardvark/PrivateCategories/NSFileHandle+ARKAdditions.m
@@ -64,10 +64,12 @@ typedef unsigned long long ARKFileOffset;
 
 - (void)ARK_writeDataBlock:(NSData *)dataBlock;
 {
-    bool hasEncounteredException = atomic_load(&__ARKHasEncounteredDiskSizeException);
     bool preventWritesAfterException = atomic_load(&__ARKPreventsWritesAfterException);
-    if (hasEncounteredException && preventWritesAfterException) {
-        return;
+    if (preventWritesAfterException) {
+        bool hasEncounteredException = atomic_load(&__ARKHasEncounteredDiskSizeException);
+        if (hasEncounteredException) {
+            return;
+        }
     }
 
     NSUInteger dataBlockLength = dataBlock.length;


### PR DESCRIPTION
Under ARC, the lifetime of a variable caught in an exception does not end when a scope ends https://clang.llvm.org/docs/AutomaticReferenceCounting.html#exceptions (previously discussed in this PR: https://github.com/square/Aardvark/pull/134)

Since leaking memory is also bad + leads to other issues (crashes) if enough data is logged: let's introduce the ability to automatically turn off logging for the current session when Aardvark encounters an out-of-disk-space exception.  I'm intentionally being narrow in only doing this in response to `NSFileHandleOperationException` because it's

1. the most common case; and
2. while I suspect that this handling is sufficient for all cases, I haven't done a huge examination of what else could crop up! I'd rather fall back to known behavior than do the wrong thing here

The alternatives to turning off logging are:
1. Crashing. This is bad, and we chose not to crash in this situation last summer https://github.com/square/Aardvark/pull/131
2. Silently swallowing exceptions. We de-facto chose to do this last summer by catching-but-not-acting-on exceptions, and I'm not sure it's good enough.
3. Rewrite everything in Swift. Would be neat! Exceptions have different behavior there. But larger in scope? Not something I have the appetite for at the moment, at least.
4. ??? something else that I'm not thinking of!