### PR TITLE
Add privacy manifest

### DIFF
--- a/Aardvark.podspec
+++ b/Aardvark.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '12.0'
 
   s.source_files = 'Sources/Aardvark/**/*.{h,m,swift}'
+  s.resource_bundle = {'Aardvark' => ['Sources/Aardvark/PrivacyInfo.xcprivacy']}
 
   s.dependency 'CoreAardvark', '~> 3.0'
 end

--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 		4551A3071BDAF93A00F216D0 /* ARKScreenshotLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKScreenshotLogging.h; sourceTree = "<group>"; };
 		4551A3081BDAF93A00F216D0 /* ARKScreenshotLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKScreenshotLogging.m; sourceTree = "<group>"; };
 		BDC3E4A62B30F29500766280 /* DictionaryAttachmentGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryAttachmentGenerator.swift; sourceTree = "<group>"; };
+		BDB50C1E2B2B72F500C134FC /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Aardvark/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D04D47EC1AB8A0BA00A342E9 /* ARKDataArchiveTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKDataArchiveTests.m; sourceTree = "<group>"; };
 		D04D48041AB9196B00A342E9 /* ARKFileHandleAdditionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKFileHandleAdditionsTests.m; sourceTree = "<group>"; };
 		EA09D3C41A2E6D2F004C1125 /* ARKDefineTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKDefineTests.m; sourceTree = "<group>"; };
@@ -481,6 +482,7 @@
 			children = (
 				EAD1442419E073FB0065A1FF /* Aardvark.h */,
 				EA90BF9F1D49570F00BA9640 /* Info.plist */,
+				BDB50C1E2B2B72F500C134FC /* PrivacyInfo.xcprivacy */,
 			);
 			name = Other;
 			path = ..;

--- a/Sources/Aardvark/PrivacyInfo.xcprivacy
+++ b/Sources/Aardvark/PrivacyInfo.xcprivacy
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>7D9E.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
This adds a privacy manifest to the library that declares the [reasons for using sensitive APIs](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api). This is a [new requirement by Apple](https://developer.apple.com/news/?id=z6fu1dcu) and will start being enforced in spring 2024. Any app that consumes Aardvark would get this privacy manifest and doesn't need to redeclare the libraries usage of sensitive APIs.

Out of all sensitive APIs marked by Apple, Aardvark uses 1 file timestamp API, 4 disk space APIs, and the `UserDefaults`.

## Timestamp API

When a bug report is being filed, one of the email attachments lists some files from the app container along with their last modified date. [contentModificationDateKey](https://developer.apple.com/documentation/foundation/urlresourcekey/1408803-contentmodificationdatekey) is used [here](https://github.com/square/Aardvark/blob/58ac87133a6e3eb8f4cf5ce278d5d0c89518f141/Sources/Aardvark/BugReporting/FileSystemAttachmentGenerator.swift#L82) to fetch those dates, which are visible to users in the attachment itself. Below is an example.

<img width=500 src="https://github.com/square/Aardvark/assets/2532658/58ecc8f7-98a1-4aae-9d0e-79042e3a226d"/>

This qualifies as reason **C617.1** which states:
> Declare this reason to access the timestamps, size, or other metadata of files inside the app container, app group container, or the app’s CloudKit container.

## File size APIs

Also when a bug report is being filed, in the same attachment as above, disk information is included. This is done [here](https://github.com/square/Aardvark/blob/58ac87133a6e3eb8f4cf5ce278d5d0c89518f141/Sources/Aardvark/BugReporting/FileSystemAttachmentGenerator.swift#L281C1-L286) and makes use of the following sensitive APIs:
* [volumeAvailableCapacityKey](https://developer.apple.com/documentation/foundation/urlresourcekey/1412898-volumeavailablecapacitykey)
* [volumeAvailableCapacityForImportantUsageKey](https://developer.apple.com/documentation/foundation/urlresourcekey/2887126-volumeavailablecapacityforimport)
* [volumeAvailableCapacityForOpportunisticUsageKey](https://developer.apple.com/documentation/foundation/urlresourcekey/2887125-volumeavailablecapacityforopport)
* [volumeTotalCapacityKey](https://developer.apple.com/documentation/foundation/urlresourcekey/1415933-volumetotalcapacitykey)

Below is an example of what this looks like:

<img width=500 src="https://github.com/square/Aardvark/assets/2532658/c8ab31ea-fea5-4aee-a562-fdee1f116d28"/>

This qualifies as reason **7D9E.1** which is specific to filing bug reports and states:
> Declare this reason to include disk space information in an optional bug report that the person using the device chooses to submit. The disk space information must be prominently displayed to the person as part of the report.
Information accessed for this reason, or any derived information, may be sent off-device only after the user affirmatively chooses to submit the specific bug report including disk space information, and only for the purpose of investigating or responding to the bug report.