### PR TITLE
Change UserDefaults reporting to more broad keys/values

### DIFF
--- a/Aardvark.xcodeproj/project.pbxproj
+++ b/Aardvark.xcodeproj/project.pbxproj
@@ -55,9 +55,9 @@
 		3DD020DF2556502E00E6400A /* ARKDefaultLogFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EAAB38A319E2929C00161A54 /* ARKDefaultLogFormatterTests.m */; };
 		3DF0CB54261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF0CB53261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift */; };
 		3DFD7B5226F551C8000CE4B8 /* FileSystemAttachmentGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD7B5026F5519D000CE4B8 /* FileSystemAttachmentGeneratorTests.swift */; };
-		3DFD25DB26F3FD82000CE4B8 /* UserDefaultsAttachmentGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD25DA26F3FD82000CE4B8 /* UserDefaultsAttachmentGenerator.swift */; };
 		4551A2D91BDAD10E00F216D0 /* Aardvark.h in Headers */ = {isa = PBXBuildFile; fileRef = EAD1442419E073FB0065A1FF /* Aardvark.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4551A30A1BDAF93A00F216D0 /* ARKScreenshotLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 4551A3071BDAF93A00F216D0 /* ARKScreenshotLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BDC3E4A72B30F29500766280 /* DictionaryAttachmentGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC3E4A62B30F29500766280 /* DictionaryAttachmentGenerator.swift */; };
 		EA3C1D961D934A210048C4CD /* CoreAardvark.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAF2FEA01D47172400931663 /* CoreAardvark.framework */; };
 		EA3C1DA51D934A260048C4CD /* Aardvark.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4551A2C21BDACF9000F216D0 /* Aardvark.framework */; };
 		EA3C1DAC1D934B1D0048C4CD /* ARKDataArchiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D04D47EC1AB8A0BA00A342E9 /* ARKDataArchiveTests.m */; };
@@ -180,10 +180,10 @@
 		3DA5BF5F2556640100B6D148 /* ARKBugReportAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARKBugReportAttachmentTests.swift; sourceTree = "<group>"; };
 		3DF0CB53261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemAttachmentGenerator.swift; sourceTree = "<group>"; };
 		3DFD7B5026F5519D000CE4B8 /* FileSystemAttachmentGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemAttachmentGeneratorTests.swift; sourceTree = "<group>"; };
-		3DFD25DA26F3FD82000CE4B8 /* UserDefaultsAttachmentGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsAttachmentGenerator.swift; sourceTree = "<group>"; };
 		4551A2C21BDACF9000F216D0 /* Aardvark.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Aardvark.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4551A3071BDAF93A00F216D0 /* ARKScreenshotLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKScreenshotLogging.h; sourceTree = "<group>"; };
 		4551A3081BDAF93A00F216D0 /* ARKScreenshotLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKScreenshotLogging.m; sourceTree = "<group>"; };
+		BDC3E4A62B30F29500766280 /* DictionaryAttachmentGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryAttachmentGenerator.swift; sourceTree = "<group>"; };
 		D04D47EC1AB8A0BA00A342E9 /* ARKDataArchiveTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKDataArchiveTests.m; sourceTree = "<group>"; };
 		D04D48041AB9196B00A342E9 /* ARKFileHandleAdditionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKFileHandleAdditionsTests.m; sourceTree = "<group>"; };
 		EA09D3C41A2E6D2F004C1125 /* ARKDefineTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKDefineTests.m; sourceTree = "<group>"; };
@@ -471,7 +471,7 @@
 				3D81BC4325C50A9800E61A49 /* ViewHierarchyAttachmentGenerator.swift */,
 				3D81BC5725C54A0800E61A49 /* LogStoreAttachmentGenerator.swift */,
 				3DF0CB53261C6F4600B02A7C /* FileSystemAttachmentGenerator.swift */,
-				3DFD25DA26F3FD82000CE4B8 /* UserDefaultsAttachmentGenerator.swift */,
+				BDC3E4A62B30F29500766280 /* DictionaryAttachmentGenerator.swift */,
 			);
 			path = BugReporting;
 			sourceTree = "<group>";
@@ -952,6 +952,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BDC3E4A72B30F29500766280 /* DictionaryAttachmentGenerator.swift in Sources */,
 				EA98B9531D4BF43400B3A390 /* ARKScreenshotLogging.m in Sources */,
 				3D81BC5825C54A0800E61A49 /* LogStoreAttachmentGenerator.swift in Sources */,
 				3D9F0A15255BC728000E63D7 /* ARKEmailAttachment.swift in Sources */,
@@ -962,7 +963,6 @@
 				3DA5BF5D2556626800B6D148 /* UIApplication+ARKAdditions.swift in Sources */,
 				EA98B9621D4BFA1700B3A390 /* Aardvark.swift in Sources */,
 				3D6066B326BA1174004D9203 /* ARKBugReporter.swift in Sources */,
-				3DFD25DB26F3FD82000CE4B8 /* UserDefaultsAttachmentGenerator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AardvarkSample/AardvarkSample.xcodeproj/project.pbxproj
+++ b/AardvarkSample/AardvarkSample.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3D046DD9254D5ACB0045A06C /* AardvarkLoggingUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3D046DD5254D5ACB0045A06C /* AardvarkLoggingUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3DA5BF6C2559D38F00B6D148 /* AardvarkMailUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DA5BF692559D38F00B6D148 /* AardvarkMailUI.framework */; };
 		3DA5BF6D2559D38F00B6D148 /* AardvarkMailUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3DA5BF692559D38F00B6D148 /* AardvarkMailUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		BD1CA8D32B30EFC7007A0FBF /* SampleUserDefaultsKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1CA8D22B30EFC7007A0FBF /* SampleUserDefaultsKeys.swift */; };
 		EA3C1DDD1D93696D0048C4CD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3C1DDC1D93696D0048C4CD /* AppDelegate.swift */; };
 		EA3C1DE21D93696D0048C4CD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EA3C1DE01D93696D0048C4CD /* Main.storyboard */; };
 		EA3C1DE41D93696D0048C4CD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EA3C1DE31D93696D0048C4CD /* Assets.xcassets */; };
@@ -128,6 +129,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		BD1CA8D22B30EFC7007A0FBF /* SampleUserDefaultsKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleUserDefaultsKeys.swift; sourceTree = "<group>"; };
 		EA3C1DD91D93696D0048C4CD /* AardvarkSample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AardvarkSample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA3C1DDC1D93696D0048C4CD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		EA3C1DE11D93696D0048C4CD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 				EA3C1E071D936A1C0048C4CD /* LaunchScreen.xib */,
 				EA3C1DE81D93696D0048C4CD /* Info.plist */,
 				EA3C1E0A1D936B7B0048C4CD /* SampleViewController.swift */,
+				BD1CA8D22B30EFC7007A0FBF /* SampleUserDefaultsKeys.swift */,
 				EA3C1E121D93744A0048C4CD /* SampleCrashlyticsLogObserver.h */,
 				EA3C1E131D93744A0048C4CD /* SampleCrashlyticsLogObserver.m */,
 			);
@@ -356,6 +359,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BD1CA8D32B30EFC7007A0FBF /* SampleUserDefaultsKeys.swift in Sources */,
 				EA3C1E141D93744A0048C4CD /* SampleCrashlyticsLogObserver.m in Sources */,
 				EA3C1DDD1D93696D0048C4CD /* AppDelegate.swift in Sources */,
 				EA3C1E0B1D936B7B0048C4CD /* SampleViewController.swift in Sources */,

--- a/AardvarkSample/AardvarkSample/AppDelegate.swift
+++ b/AardvarkSample/AardvarkSample/AppDelegate.swift
@@ -83,7 +83,11 @@ extension SampleAppDelegate: ARKEmailBugReporterEmailAttachmentAdditionsDelegate
     ) -> [ARKBugReportAttachment]? {
         return [
             try? FileSystemAttachmentGenerator.attachment(),
-            try? UserDefaultsAttachmentGenerator.attachment(),
+            try? DictionaryAttachmentGenerator.attachment(
+                for: UserDefaults.standard.dictionaryRepresentation(),
+                includedKeys: SampleUserDefaultsKeys.allCases.map { $0.rawValue },
+                named: "user_defaults"
+            )
         ].compactMap { $0 }
     }
 

--- a/AardvarkSample/AardvarkSample/SampleUserDefaultsKeys.swift
+++ b/AardvarkSample/AardvarkSample/SampleUserDefaultsKeys.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright © 2023 Block, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+enum SampleUserDefaultsKeys: String, CaseIterable {
+    case boolean = "com.squareup.AardvarkSample.SampleBooleanKey"
+    case integer = "com.squareup.AardvarkSample.SampleIntegerKey"
+    case string = "com.squareup.AardvarkSample.SampleStringKey"
+}

--- a/AardvarkSample/AardvarkSample/SampleViewController.swift
+++ b/AardvarkSample/AardvarkSample/SampleViewController.swift
@@ -207,9 +207,9 @@ class SampleViewController : UIViewController {
     private func writeSampleDataToUserDefaults() {
         let userDefaults = UserDefaults.standard
 
-        userDefaults.set(true, forKey: "com.squareup.AardvarkSample.SampleBooleanKey")
-        userDefaults.set(5, forKey: "com.squareup.AardvarkSample.SampleIntegerKey")
-        userDefaults.set("Testing", forKey: "com.squareup.AardvarkSample.SampleStringKey")
+        userDefaults.set(true, forKey: SampleUserDefaultsKeys.boolean.rawValue)
+        userDefaults.set(5, forKey: SampleUserDefaultsKeys.integer.rawValue)
+        userDefaults.set("Testing", forKey: SampleUserDefaultsKeys.string.rawValue)
     }
 
 }


### PR DESCRIPTION
This removes the ability to add the contents of `UserDefaults` as an attachment when filing a bug report. This is needed to comply with Apple's new [sensitive API requirements](https://developer.apple.com/news/?id=z6fu1dcu).
More specifically, under [UserDefaults](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401), Apple states:
> C56D.1
Declare this reason if your third-party SDK is providing a wrapper function around user defaults API(s) for the app to use, and you only access the user defaults APIs when the app calls your wrapper function. This reason may only be declared by third-party SDKs. This reason may not be declared if your third-party SDK was created primarily to wrap required reason API(s).
Information accessed for this reason, or any derived information, may not be used for your third-party SDK’s own purposes or sent off-device by your third-party SDK.

The focus is on `UserDefaults` values not allowed to be sent off-device. By contrast, under the [Disk space APIs](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278397), there's an explicit callout to bug reports as an exception, but it doesn't look like this applies for `UserDefaults`.

This change should protect apps using `Aardvark` from facing future App Store distribution issues related to the usage of sensitive APIs in the SDK itself.