### PR TITLE
Update missing NSPrivacyCollectedDataTypes in PrivacyInfo.xcprivacy

### DIFF
--- a/Aardvark.podspec
+++ b/Aardvark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Aardvark'
-  s.version  = '5.0.0'
+  s.version  = '5.1.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark is a library that makes it dead simple to create actionable bug reports.'
   s.homepage = 'https://github.com/square/Aardvark'

--- a/AardvarkMailUI.podspec
+++ b/AardvarkMailUI.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/AardvarkMailUI/**/*.{h,m,swift}'
   s.private_header_files = 'Sources/AardvarkMailUI/**/*_Testing.h', 'Sources/AardvarkMailUI/PrivateCategories/*.h'
 
-  s.dependency 'Aardvark', '~> 5.0.0'
+  s.dependency 'Aardvark', '~> 5.1.0'
 end

--- a/Sources/Aardvark/PrivacyInfo.xcprivacy
+++ b/Sources/Aardvark/PrivacyInfo.xcprivacy
@@ -21,5 +21,7 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
* While generating a privacy report for Reader SDK 1, we noticed that the report errored due to Aardvark not containing a NSPrivacyCollectedDataTypes in its PrivacyInfo.xcprivacy file, which could lead to possible App Store rejections for developers and SPOS in the future.
* This PR simply adds an empty `NSPrivacyCollectedDataTypes` to the existing privacy manifest, which should resolve any privacy report errors.

![Screenshot 2024-08-28 at 10 52 41 AM](https://github.com/user-attachments/assets/1dbab34b-47a8-450d-a09e-b3ea069fb886)
