### PR TITLE
Bump AardvarkMailUI to 2.0.1

### DIFF
--- a/AardvarkMailUI.podspec
+++ b/AardvarkMailUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'AardvarkMailUI'
-  s.version  = '2.0.0'
+  s.version  = '2.0.1'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Aardvark components for submitting a bug report via an email composer.'
   s.homepage = 'https://github.com/square/Aardvark'


### PR DESCRIPTION
Sorry about this again, we do need to bump the Podspec for 2.0.1 after all (and then this saga will finally come to a close)