### PR TITLE
Remove unused `.swift` extension from AardvarkLoggingUI's podspec

### DIFF
--- a/AardvarkLoggingUI.podspec
+++ b/AardvarkLoggingUI.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.ios.deployment_target = '14.0'
 
-  s.source_files = 'Sources/AardvarkLoggingUI/**/*.{h,m,swift}'
+  s.source_files = 'Sources/AardvarkLoggingUI/**/*.{h,m}'
   s.private_header_files = 'Sources/AardvarkLoggingUI/**/*_Testing.h', 'Sources/AardvarkLoggingUI/PrivateCategories/*.h'
 
   s.dependency 'CoreAardvark', '~> 4.0'


### PR DESCRIPTION
Removes the `.swift` extension from AardvarkLoggingUI's `source_files` since it doesn't contain any Swift.  Fixes https://github.com/square/Aardvark/issues/133.