### PR TITLE
Fix: the module 'Aardvark' has no member named 'addDefaultBugReportingGestureWithEmailBugReporter` in SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,12 +14,20 @@ let package = Package(
             targets: ["Aardvark", "AardvarkSwift"]
         ),
         .library(
+            name: "AardvarkSwift",
+            targets: ["AardvarkSwift"]
+        ),
+        .library(
             name: "AardvarkLoggingUI",
             targets: ["AardvarkLoggingUI"]
         ),
         .library(
             name: "AardvarkMailUI",
             targets: ["AardvarkMailUI", "AardvarkMailUISwift"]
+        ),
+        .library(
+            name: "AardvarkMailUISwift",
+            targets: ["AardvarkMailUISwift"]
         ),
 		.library(
             name: "CoreAardvark",

--- a/Sources/AardvarkMailUISwift/Aardvark+EmailBugReporting.swift
+++ b/Sources/AardvarkMailUISwift/Aardvark+EmailBugReporting.swift
@@ -19,6 +19,9 @@ import Aardvark
 #if SWIFT_PACKAGE
 import AardvarkSwift
 import AardvarkMailUI
+
+/// Re-export the Aardvark class so consumers can use `Aardvark.methodName()` syntax
+public typealias Aardvark = AardvarkSwift.Aardvark
 #endif
 
 extension Aardvark {
@@ -32,7 +35,7 @@ extension Aardvark {
         let logStore = ARKLogDistributor.default().defaultLogStore
         let bugReporter = ARKEmailBugReporter(emailAddress: emailAddress, logStore: logStore)
 
-        let gestureRecognizer = Aardvark.add(
+        let gestureRecognizer = Self.add(
             bugReporter: bugReporter,
             triggeringGestureRecognizerClass: UILongPressGestureRecognizer.self
         )


### PR DESCRIPTION
### Fix module/class name collision for SPM builds
When building with Swift Package Manager, the Aardvark module name shadows the Aardvark class, causing Aardvark.addDefaultBugReportingGestureWithEmailBugReporter to be inaccessible.

Changes:
* Expose AardvarkSwift and AardvarkMailUISwift as standalone products in Package.swift
* Add typealias to re-export Aardvark class under SPM builds
* Use Self in extension to avoid duplication